### PR TITLE
fix: css 파일을 제공하도록 변경

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,5 @@
   "access": "restricted",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["@sipe-team/component"]
+  "ignore": ["@sipe-team/package-name"]
 }

--- a/.changeset/fifty-jeans-own.md
+++ b/.changeset/fifty-jeans-own.md
@@ -1,0 +1,12 @@
+---
+"@sipe-team/radio-group": patch
+"@sipe-team/typography": patch
+"@sipe-team/skeleton": patch
+"@sipe-team/divider": patch
+"@sipe-team/tooltip": patch
+"@sipe-team/switch": patch
+"@sipe-team/input": patch
+"@sipe-team/card": patch
+---
+
+fix: exports

--- a/.changeset/nice-pillows-repeat.md
+++ b/.changeset/nice-pillows-repeat.md
@@ -1,0 +1,14 @@
+---
+"@sipe-team/radio-group": patch
+"@sipe-team/typography": patch
+"@sipe-team/skeleton": patch
+"@sipe-team/divider": patch
+"@sipe-team/tooltip": patch
+"@sipe-team/switch": patch
+"@sipe-team/input": patch
+"@sipe-team/badge": patch
+"@sipe-team/card": patch
+"@sipe-team/side": patch
+---
+
+fix: styles.css

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,21 @@
+{
+  "mode": "pre",
+  "tag": "next",
+  "initialVersions": {
+    "@sipe-team/package-name": "0.0.0",
+    "@sipe-team/input": "0.0.2",
+    "@sipe-team/badge": "0.0.2",
+    "@sipe-team/card": "0.0.1",
+    "@sipe-team/divider": "0.0.1",
+    "@sipe-team/radio-group": "0.0.1",
+    "@sipe-team/side": "0.0.2",
+    "@sipe-team/skeleton": "0.0.1",
+    "@sipe-team/switch": "0.0.1",
+    "@sipe-team/tokens": "0.1.0",
+    "@sipe-team/tooltip": "0.0.2",
+    "@sipe-team/typography": "0.0.3"
+  },
+  "changesets": [
+    "nice-pillows-repeat"
+  ]
+}

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -16,6 +16,7 @@
     "@sipe-team/typography": "0.0.3"
   },
   "changesets": [
+    "fifty-jeans-own",
     "nice-pillows-repeat"
   ]
 }

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "next",
   "initialVersions": {
     "@sipe-team/package-name": "0.0.0",

--- a/.templates/component/package.json
+++ b/.templates/component/package.json
@@ -54,7 +54,8 @@
           "types": "./dist/index.d.cts",
           "default": "./dist/index.cjs"
         }
-      }
+      },
+      "./styles.css": "./dist/index.css"
     }
   },
   "sideEffects": false

--- a/packages/Input/CHANGELOG.md
+++ b/packages/Input/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @sipe-team/input
 
+## 0.0.3-next.0
+
+### Patch Changes
+
+- 27c312a: fix: styles.css
+
 ## 0.0.2
 
 ### Patch Changes

--- a/packages/Input/CHANGELOG.md
+++ b/packages/Input/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @sipe-team/input
 
+## 0.0.3-next.1
+
+### Patch Changes
+
+- fix: exports
+
 ## 0.0.3-next.0
 
 ### Patch Changes

--- a/packages/Input/package.json
+++ b/packages/Input/package.json
@@ -9,9 +9,7 @@
   },
   "type": "module",
   "exports": "./src/index.ts",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "scripts": {
     "build": "tsup",
     "build:storybook": "storybook build",
@@ -62,7 +60,8 @@
           "default": "./dist/index.cjs"
         }
       }
-    }
+    },
+    "./styles.css": "./dist/index.css"
   },
   "sideEffects": false
 }

--- a/packages/Input/package.json
+++ b/packages/Input/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sipe-team/input",
   "description": "Input component for Sipe Design System",
-  "version": "0.0.3-next.0",
+  "version": "0.0.3-next.1",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -61,9 +61,9 @@
           "types": "./dist/index.d.cts",
           "default": "./dist/index.cjs"
         }
-      }
-    },
-    "./styles.css": "./dist/index.css"
+      },
+      "./styles.css": "./dist/index.css"
+    }
   },
   "sideEffects": false
 }

--- a/packages/Input/package.json
+++ b/packages/Input/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sipe-team/input",
   "description": "Input component for Sipe Design System",
-  "version": "0.0.2",
+  "version": "0.0.3-next.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -9,7 +9,9 @@
   },
   "type": "module",
   "exports": "./src/index.ts",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsup",
     "build:storybook": "storybook build",

--- a/packages/badge/CHANGELOG.md
+++ b/packages/badge/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @sipe-team/badge
 
+## 0.0.3-next.0
+
+### Patch Changes
+
+- 27c312a: fix: styles.css
+- Updated dependencies [27c312a]
+  - @sipe-team/typography@0.0.4-next.0
+
 ## 0.0.2
 
 ### Patch Changes
@@ -7,7 +15,6 @@
 - e6f76c0: fix: css module bundle
 - Updated dependencies [e6f76c0]
   - @sipe-team/typography@0.0.3
-
 
 ## 0.0.2-next.0
 

--- a/packages/badge/CHANGELOG.md
+++ b/packages/badge/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @sipe-team/badge
 
+## 0.0.3-next.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @sipe-team/typography@0.0.4-next.1
+
 ## 0.0.3-next.0
 
 ### Patch Changes

--- a/packages/badge/package.json
+++ b/packages/badge/package.json
@@ -9,9 +9,7 @@
   },
   "type": "module",
   "exports": "./src/index.ts",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "scripts": {
     "build": "tsup",
     "build:storybook": "storybook build",
@@ -61,7 +59,8 @@
           "types": "./dist/index.d.cts",
           "default": "./dist/index.cjs"
         }
-      }
+      },
+      "./styles.css": "./dist/index.css"
     }
   },
   "sideEffects": false

--- a/packages/badge/package.json
+++ b/packages/badge/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sipe-team/badge",
   "description": "Badge component for Sipe Design System",
-  "version": "0.0.2",
+  "version": "0.0.3-next.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -9,7 +9,9 @@
   },
   "type": "module",
   "exports": "./src/index.ts",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsup",
     "build:storybook": "storybook build",

--- a/packages/badge/package.json
+++ b/packages/badge/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sipe-team/badge",
   "description": "Badge component for Sipe Design System",
-  "version": "0.0.3-next.0",
+  "version": "0.0.3-next.1",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/card/CHANGELOG.md
+++ b/packages/card/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @sipe-team/card
 
+## 0.0.2-next.1
+
+### Patch Changes
+
+- fix: exports
+  - @sipe-team/tokens@0.1.0
+
 ## 0.0.2-next.0
 
 ### Patch Changes

--- a/packages/card/CHANGELOG.md
+++ b/packages/card/CHANGELOG.md
@@ -1,9 +1,15 @@
 # @sipe-team/card
 
+## 0.0.2-next.0
+
+### Patch Changes
+
+- 27c312a: fix: styles.css
+  - @sipe-team/tokens@0.1.0
+
 ## 0.0.1
 
 ### Patch Changes
 
 - e6f76c0: fix: css module bundle
   - @sipe-team/tokens@0.1.0
-

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sipe-team/card",
   "description": "Card component for Sipe Design System",
-  "version": "0.0.1",
+  "version": "0.0.2-next.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -9,7 +9,9 @@
   },
   "type": "module",
   "exports": "./src/index.ts",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsup",
     "build:storybook": "storybook build",

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -9,9 +9,7 @@
   },
   "type": "module",
   "exports": "./src/index.ts",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "scripts": {
     "build": "tsup",
     "build:storybook": "storybook build",
@@ -63,7 +61,8 @@
           "default": "./dist/index.cjs"
         }
       }
-    }
+    },
+    "./styles.css": "./dist/index.css"
   },
   "sideEffects": false
 }

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sipe-team/card",
   "description": "Card component for Sipe Design System",
-  "version": "0.0.2-next.0",
+  "version": "0.0.2-next.1",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -62,9 +62,9 @@
           "types": "./dist/index.d.cts",
           "default": "./dist/index.cjs"
         }
-      }
-    },
-    "./styles.css": "./dist/index.css"
+      },
+      "./styles.css": "./dist/index.css"
+    }
   },
   "sideEffects": false
 }

--- a/packages/divider/CHANGELOG.md
+++ b/packages/divider/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @sipe-team/divider
 
+## 0.0.2-next.1
+
+### Patch Changes
+
+- fix: exports
+
 ## 0.0.2-next.0
 
 ### Patch Changes

--- a/packages/divider/CHANGELOG.md
+++ b/packages/divider/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @sipe-team/divider
 
+## 0.0.2-next.0
+
+### Patch Changes
+
+- 27c312a: fix: styles.css
+
 ## 0.0.1
 
 ### Patch Changes

--- a/packages/divider/package.json
+++ b/packages/divider/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sipe-team/divider",
   "description": "divider component for Sipe Design System",
-  "version": "0.0.1",
+  "version": "0.0.2-next.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -9,7 +9,9 @@
   },
   "type": "module",
   "exports": "./src/index.ts",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsup",
     "build:storybook": "storybook build",

--- a/packages/divider/package.json
+++ b/packages/divider/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sipe-team/divider",
   "description": "divider component for Sipe Design System",
-  "version": "0.0.2-next.0",
+  "version": "0.0.2-next.1",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -56,9 +56,9 @@
           "types": "./dist/index.d.cts",
           "default": "./dist/index.cjs"
         }
-      }
-    },
-    "./styles.css": "./dist/index.css"
+      },
+      "./styles.css": "./dist/index.css"
+    }
   },
   "sideEffects": false,
   "dependencies": {

--- a/packages/divider/package.json
+++ b/packages/divider/package.json
@@ -9,9 +9,7 @@
   },
   "type": "module",
   "exports": "./src/index.ts",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "scripts": {
     "build": "tsup",
     "build:storybook": "storybook build",
@@ -57,7 +55,8 @@
           "default": "./dist/index.cjs"
         }
       }
-    }
+    },
+    "./styles.css": "./dist/index.css"
   },
   "sideEffects": false,
   "dependencies": {

--- a/packages/radio-group/CHANGELOG.md
+++ b/packages/radio-group/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @sipe-team/radio-group
 
+## 0.0.2-next.1
+
+### Patch Changes
+
+- fix: exports
+
 ## 0.0.2-next.0
 
 ### Patch Changes

--- a/packages/radio-group/CHANGELOG.md
+++ b/packages/radio-group/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @sipe-team/radio-group
 
+## 0.0.2-next.0
+
+### Patch Changes
+
+- 27c312a: fix: styles.css
+
 ## 0.0.1
 
 ### Patch Changes

--- a/packages/radio-group/package.json
+++ b/packages/radio-group/package.json
@@ -9,9 +9,7 @@
   },
   "type": "module",
   "exports": "./src/index.ts",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "scripts": {
     "build": "tsup",
     "build:storybook": "storybook build",
@@ -58,7 +56,8 @@
           "default": "./dist/index.cjs"
         }
       }
-    }
+    },
+    "./styles.css": "./dist/index.css"
   },
   "sideEffects": false
 }

--- a/packages/radio-group/package.json
+++ b/packages/radio-group/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sipe-team/radio-group",
   "description": "Radio Group component for Sipe Design System",
-  "version": "0.0.2-next.0",
+  "version": "0.0.2-next.1",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -57,9 +57,9 @@
           "types": "./dist/index.d.cts",
           "default": "./dist/index.cjs"
         }
-      }
-    },
-    "./styles.css": "./dist/index.css"
+      },
+      "./styles.css": "./dist/index.css"
+    }
   },
   "sideEffects": false
 }

--- a/packages/radio-group/package.json
+++ b/packages/radio-group/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sipe-team/radio-group",
   "description": "Radio Group component for Sipe Design System",
-  "version": "0.0.1",
+  "version": "0.0.2-next.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -9,7 +9,9 @@
   },
   "type": "module",
   "exports": "./src/index.ts",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsup",
     "build:storybook": "storybook build",

--- a/packages/side/CHANGELOG.md
+++ b/packages/side/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @sipe-team/side
 
+## 0.0.3-next.0
+
+### Patch Changes
+
+- 27c312a: fix: styles.css
+- Updated dependencies [27c312a]
+  - @sipe-team/radio-group@0.0.2-next.0
+  - @sipe-team/typography@0.0.4-next.0
+  - @sipe-team/skeleton@0.0.2-next.0
+  - @sipe-team/divider@0.0.2-next.0
+  - @sipe-team/tooltip@0.0.3-next.0
+  - @sipe-team/switch@0.0.2-next.0
+  - @sipe-team/input@0.0.3-next.0
+  - @sipe-team/badge@0.0.3-next.0
+  - @sipe-team/card@0.0.2-next.0
+  - @sipe-team/tokens@0.1.0
+
 ## 0.0.2
 
 ### Patch Changes

--- a/packages/side/CHANGELOG.md
+++ b/packages/side/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @sipe-team/side
 
+## 0.0.3-next.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @sipe-team/radio-group@0.0.2-next.1
+  - @sipe-team/typography@0.0.4-next.1
+  - @sipe-team/skeleton@0.0.2-next.1
+  - @sipe-team/divider@0.0.2-next.1
+  - @sipe-team/tooltip@0.0.3-next.1
+  - @sipe-team/switch@0.0.2-next.1
+  - @sipe-team/input@0.0.3-next.1
+  - @sipe-team/card@0.0.2-next.1
+  - @sipe-team/badge@0.0.3-next.1
+  - @sipe-team/tokens@0.1.0
+
 ## 0.0.3-next.0
 
 ### Patch Changes

--- a/packages/side/package.json
+++ b/packages/side/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sipe-team/side",
   "description": "Sipe Design System",
-  "version": "0.0.3-next.0",
+  "version": "0.0.3-next.1",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/side/package.json
+++ b/packages/side/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sipe-team/side",
   "description": "Sipe Design System",
-  "version": "0.0.2",
+  "version": "0.0.3-next.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -9,7 +9,10 @@
   },
   "type": "module",
   "exports": "./src/index.ts",
-  "files": ["dist", "styles.css"],
+  "files": [
+    "dist",
+    "styles.css"
+  ],
   "scripts": {
     "build": "tsup",
     "prepack": "pnpm run build"

--- a/packages/side/package.json
+++ b/packages/side/package.json
@@ -9,9 +9,7 @@
   },
   "type": "module",
   "exports": "./src/index.ts",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist", "styles.css"],
   "scripts": {
     "build": "tsup",
     "prepack": "pnpm run build"
@@ -47,7 +45,8 @@
           "types": "./dist/index.d.cts",
           "default": "./dist/index.cjs"
         }
-      }
+      },
+      "./styles.css": "./styles.css"
     }
   },
   "sideEffects": false

--- a/packages/side/styles.css
+++ b/packages/side/styles.css
@@ -1,0 +1,9 @@
+@import "~@sipe-team/badge/styles.css";
+@import "~@sipe-team/card/styles.css";
+@import "~@sipe-team/divider/styles.css";
+@import "~@sipe-team/input/styles.css";
+@import "~@sipe-team/radio-group/styles.css";
+@import "~@sipe-team/skeleton/styles.css";
+@import "~@sipe-team/switch/styles.css";
+@import "~@sipe-team/tooltip/styles.css";
+@import "~@sipe-team/typography/styles.css";

--- a/packages/skeleton/CHANGELOG.md
+++ b/packages/skeleton/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @sipe-team/skeleton
 
+## 0.0.2-next.1
+
+### Patch Changes
+
+- fix: exports
+
 ## 0.0.2-next.0
 
 ### Patch Changes

--- a/packages/skeleton/CHANGELOG.md
+++ b/packages/skeleton/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @sipe-team/skeleton
 
+## 0.0.2-next.0
+
+### Patch Changes
+
+- 27c312a: fix: styles.css
+
 ## 0.0.1
 
 ### Patch Changes

--- a/packages/skeleton/package.json
+++ b/packages/skeleton/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sipe-team/skeleton",
   "description": "Skeleton component for Sipe Design System",
-  "version": "0.0.2-next.0",
+  "version": "0.0.2-next.1",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -57,9 +57,9 @@
           "types": "./dist/index.d.cts",
           "default": "./dist/index.cjs"
         }
-      }
-    },
-    "./styles.css": "./dist/index.css"
+      },
+      "./styles.css": "./dist/index.css"
+    }
   },
   "sideEffects": false,
   "dependencies": {

--- a/packages/skeleton/package.json
+++ b/packages/skeleton/package.json
@@ -9,9 +9,7 @@
   },
   "type": "module",
   "exports": "./src/index.ts",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "scripts": {
     "build": "tsup",
     "build:storybook": "storybook build",
@@ -58,7 +56,8 @@
           "default": "./dist/index.cjs"
         }
       }
-    }
+    },
+    "./styles.css": "./dist/index.css"
   },
   "sideEffects": false,
   "dependencies": {

--- a/packages/skeleton/package.json
+++ b/packages/skeleton/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sipe-team/skeleton",
   "description": "Skeleton component for Sipe Design System",
-  "version": "0.0.1",
+  "version": "0.0.2-next.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -9,7 +9,9 @@
   },
   "type": "module",
   "exports": "./src/index.ts",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsup",
     "build:storybook": "storybook build",

--- a/packages/switch/CHANGELOG.md
+++ b/packages/switch/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @sipe-team/switch
 
+## 0.0.2-next.0
+
+### Patch Changes
+
+- 27c312a: fix: styles.css
+  - @sipe-team/tokens@0.1.0
+
 ## 0.0.1
 
 ### Patch Changes

--- a/packages/switch/CHANGELOG.md
+++ b/packages/switch/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @sipe-team/switch
 
+## 0.0.2-next.1
+
+### Patch Changes
+
+- fix: exports
+  - @sipe-team/tokens@0.1.0
+
 ## 0.0.2-next.0
 
 ### Patch Changes

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -9,9 +9,7 @@
   },
   "type": "module",
   "exports": "./src/index.ts",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "scripts": {
     "build": "tsup",
     "build:storybook": "storybook build",
@@ -58,7 +56,8 @@
           "default": "./dist/index.cjs"
         }
       }
-    }
+    },
+    "./styles.css": "./dist/index.css"
   },
   "sideEffects": false,
   "dependencies": {

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sipe-team/switch",
   "description": "Switch component for Sipe Design System",
-  "version": "0.0.1",
+  "version": "0.0.2-next.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -9,7 +9,9 @@
   },
   "type": "module",
   "exports": "./src/index.ts",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsup",
     "build:storybook": "storybook build",

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sipe-team/switch",
   "description": "Switch component for Sipe Design System",
-  "version": "0.0.2-next.0",
+  "version": "0.0.2-next.1",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -57,9 +57,9 @@
           "types": "./dist/index.d.cts",
           "default": "./dist/index.cjs"
         }
-      }
-    },
-    "./styles.css": "./dist/index.css"
+      },
+      "./styles.css": "./dist/index.css"
+    }
   },
   "sideEffects": false,
   "dependencies": {

--- a/packages/tooltip/CHANGELOG.md
+++ b/packages/tooltip/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @sipe-team/tooltip
 
+## 0.0.3-next.1
+
+### Patch Changes
+
+- fix: exports
+
 ## 0.0.3-next.0
 
 ### Patch Changes

--- a/packages/tooltip/CHANGELOG.md
+++ b/packages/tooltip/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @sipe-team/tooltip
 
+## 0.0.3-next.0
+
+### Patch Changes
+
+- 27c312a: fix: styles.css
+
 ## 0.0.2
 
 ### Patch Changes

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -9,9 +9,7 @@
   },
   "type": "module",
   "exports": "./src/index.ts",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "scripts": {
     "build": "tsup",
     "build:storybook": "storybook build",
@@ -65,7 +63,8 @@
           "default": "./dist/index.cjs"
         }
       }
-    }
+    },
+    "./styles.css": "./dist/index.css"
   },
   "sideEffects": false
 }

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sipe-team/tooltip",
   "description": "Tooltip component for Sipe Design System",
-  "version": "0.0.3-next.0",
+  "version": "0.0.3-next.1",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -64,9 +64,9 @@
           "types": "./dist/index.d.cts",
           "default": "./dist/index.cjs"
         }
-      }
-    },
-    "./styles.css": "./dist/index.css"
+      },
+      "./styles.css": "./dist/index.css"
+    }
   },
   "sideEffects": false
 }

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sipe-team/tooltip",
   "description": "Tooltip component for Sipe Design System",
-  "version": "0.0.2",
+  "version": "0.0.3-next.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -9,7 +9,9 @@
   },
   "type": "module",
   "exports": "./src/index.ts",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsup",
     "build:storybook": "storybook build",

--- a/packages/typography/CHANGELOG.md
+++ b/packages/typography/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @sipe-team/typography
 
+## 0.0.4-next.0
+
+### Patch Changes
+
+- 27c312a: fix: styles.css
+  - @sipe-team/tokens@0.1.0
+
 ## 0.0.3
 
 ### Patch Changes

--- a/packages/typography/CHANGELOG.md
+++ b/packages/typography/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @sipe-team/typography
 
+## 0.0.4-next.1
+
+### Patch Changes
+
+- fix: exports
+  - @sipe-team/tokens@0.1.0
+
 ## 0.0.4-next.0
 
 ### Patch Changes

--- a/packages/typography/package.json
+++ b/packages/typography/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sipe-team/typography",
   "description": "Typography component for Sipe Design System",
-  "version": "0.0.4-next.0",
+  "version": "0.0.4-next.1",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -62,9 +62,9 @@
           "types": "./dist/index.d.cts",
           "default": "./dist/index.cjs"
         }
-      }
-    },
-    "./styles.css": "./dist/index.css"
+      },
+      "./styles.css": "./dist/index.css"
+    }
   },
   "sideEffects": false
 }

--- a/packages/typography/package.json
+++ b/packages/typography/package.json
@@ -9,9 +9,7 @@
   },
   "type": "module",
   "exports": "./src/index.ts",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "scripts": {
     "build": "tsup",
     "build:storybook": "storybook build",
@@ -63,7 +61,8 @@
           "default": "./dist/index.cjs"
         }
       }
-    }
+    },
+    "./styles.css": "./dist/index.css"
   },
   "sideEffects": false
 }

--- a/packages/typography/package.json
+++ b/packages/typography/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sipe-team/typography",
   "description": "Typography component for Sipe Design System",
-  "version": "0.0.3",
+  "version": "0.0.4-next.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -9,7 +9,9 @@
   },
   "type": "module",
   "exports": "./src/index.ts",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsup",
     "build:storybook": "storybook build",


### PR DESCRIPTION
## 변경사항
- 사이프 홈페이지에 디자인 시스템을 적용하는 과정에서 발생한 스타일을 import 할 수 없는 문제를 수정
- 개별 패키지의 `exports`필드에 `styles.css`를 명시
- `@sipe-team/side`에서 통합 스타일을 제공하는 파일 추가

## 시각자료
<!-- 참고할 수 있는 스크린샷이나 시각자료가 있으면 첨부해주세요. -->

## 체크리스트
- [ ] 기능 명세를 작성하였나요?
- [ ] 테스트 코드를 작성하였나요?

## 추가 논의사항
<!-- 추가로 알아야 할 참고사항이 있으면 적어주세요. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버전 업데이트**
	- 여러 패키지의 버전이 업데이트되었습니다 (Input, Badge, Card, Divider, Radio Group, Side, Skeleton, Switch, Tooltip, Typography).

- **새로운 기능**
	- 각 패키지에 CSS 스타일시트 내보내기 기능이 추가되었습니다.

- **버그 수정**
	- 여러 패키지의 내보내기(exports) 문제가 수정되었습니다.
	- 다양한 컴포넌트의 스타일시트 관련 문제가 해결되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->