### PR TITLE
chore(husky): add pre-push githook for branch naming convention

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,6 +1,6 @@
 # Get the current branch name
 BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
-BRANCH_REGEX='^(feature|fix|hotfix|chore|refactor|release|test|docs|ci|build)\/[a-z0-9-]+$'
+BRANCH_REGEX='^(feat|fix|hotfix|chore|refactor|release|test|docs|ci|build)\/[a-z0-9-]+$'
 
 # Check if the branch name matches the defined regex
 if ! [[ $BRANCH_NAME =~ $BRANCH_REGEX ]]; then

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,17 @@
+# Get the current branch name
+BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
+BRANCH_REGEX='^(feature|fix|hotfix|chore|refactor|release|test|docs|ci|build)\/[a-z0-9-]+$'
+
+# Check if the branch name matches the defined regex
+if ! [[ $BRANCH_NAME =~ $BRANCH_REGEX ]]; then
+   echo "Error: Invalid branch name format."
+   echo 
+   echo "Please rename your branch using:"
+   echo "git branch -m <CATEGORY>/<SUBJECT> or git branch -m <CATEGORY>/<ISSUENUMBER>-<SUBJECT>"
+   echo 
+   echo "CATEGORY: feat, fix, hotfix, chore, refactor, release, test, docs, ci, build"
+   echo
+   exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Changes

아래 이슈에 기반해서 pre-push 깃훅을 추가해봤습니다.

- https://github.com/sipe-team/3-2_side/issues/86

```sh
# Get the current branch name
BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
BRANCH_REGEX='^(feat|fix|hotfix|chore|refactor|release|test|docs|ci|build)\/[a-z0-9-]+$'

# Check if the branch name matches the defined regex
if ! [[ $BRANCH_NAME =~ $BRANCH_REGEX ]]; then
   echo "Error: Invalid branch name format."
   echo 
   echo "Please rename your branch using:"
   echo "git branch -m <CATEGORY>/<SUBJECT> or git branch -m <CATEGORY>/<ISSUENUMBER>-<SUBJECT>"
   echo 
   echo "CATEGORY: feat, fix, hotfix, chore, refactor, release, test, docs, ci, build"
   echo
   exit 1
fi

exit 0
```

## Visuals

<img width="619" alt="image" src="https://github.com/user-attachments/assets/5437fe3d-dc51-4897-80a1-83190afd06c4" />


## Checklist
- [ ] Have you written the functional specifications?
- [ ] Have you written the test code?

## Additional Discussion Points
<!-- If there are any additional points to be aware of, please specify them. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Git 브랜치 이름 규칙을 검증하는 pre-push 후크 스크립트를 추가했습니다.
	- 브랜치 이름이 지정된 형식(feature, fix, hotfix 등)을 따르지 않으면 푸시가 차단됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->