### PR TITLE
fix(flex,side): flex style export issue

### DIFF
--- a/.changeset/polite-moles-camp.md
+++ b/.changeset/polite-moles-camp.md
@@ -1,0 +1,6 @@
+---
+"@sipe-team/flex": patch
+"@sipe-team/side": patch
+---
+
+fix(flex,side): flex style export issue

--- a/packages/flex/package.json
+++ b/packages/flex/package.json
@@ -9,9 +9,7 @@
   },
   "type": "module",
   "exports": "./src/index.ts",
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "scripts": {
     "build": "tsup",
     "build:storybook": "storybook build",
@@ -63,7 +61,7 @@
           "default": "./dist/index.cjs"
         }
       },
-      "./styles.css": "./dist/styles.css"
+      "./styles.css": "./dist/index.css"
     }
   },
   "sideEffects": false

--- a/packages/side/styles.css
+++ b/packages/side/styles.css
@@ -2,6 +2,7 @@
 @import "~@sipe-team/button/styles.css";
 @import "~@sipe-team/card/styles.css";
 @import "~@sipe-team/divider/styles.css";
+@import "~@sipe-team/flex/styles.css";
 @import "~@sipe-team/input/styles.css";
 @import "~@sipe-team/radio-group/styles.css";
 @import "~@sipe-team/skeleton/styles.css";


### PR DESCRIPTION
## Changes
- Fixed incorrect export path for `styles.css` in the flex package.
- Modified side to import `styles.css` from flex.

## Visuals
<!-- If there are any screenshots or visual materials, please attach them. -->

## Checklist
- [ ] Have you written the functional specifications?
- [ ] Have you written the test code?

## Additional Discussion Points
<!-- If there are any additional points to be aware of, please specify them. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
	- `@sipe-team/flex` 및 `@sipe-team/side` 패키지의 스타일 내보내기 문제 해결
	- 스타일 가져오기 경로 업데이트

- **스타일**
	- 패키지의 스타일 설정 및 내보내기 경로 조정

<!-- end of auto-generated comment: release notes by coderabbit.ai -->