### PR TITLE
ci(husky): disabled git hook on CI

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,5 +32,6 @@ jobs:
           publish: pnpm changeset publish
           commit: "chore(release): version packages"
         env:
+          HUSKY: 0
           GITHUB_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}


### PR DESCRIPTION
## Changes

```yaml
- name: Create Release Pull Request or Publish to Github Package Registry
        id: changesets
        uses: changesets/action@v1
        with:
          version: pnpm changeset version
          publish: pnpm changeset publish
          commit: "chore(release): version packages"
        env:
          HUSKY: 0 <--
          GITHUB_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}
          NODE_AUTH_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}
```

## Visuals

<img width="707" alt="image" src="https://github.com/user-attachments/assets/30af5b5c-2c4c-4d06-8d1b-20e69f0c0bf0" />


## Checklist
- [ ] Have you written the functional specifications?
- [ ] Have you written the test code?

## Additional Discussion Points
<!-- If there are any additional points to be aware of, please specify them. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **구성 변경**
	- GitHub Actions 워크플로우에서 Husky 환경 변수를 비활성화하여 릴리스 프로세스 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->