### PR TITLE
feat(fonts): Add extraBold and black font weights to fontWeight

### DIFF
--- a/packages/tokens/src/fonts.ts
+++ b/packages/tokens/src/fonts.ts
@@ -11,6 +11,10 @@ export const fontSize = {
   48: 48,
 } as const;
 
+/**
+ * Font weights following MDN guidelines
+ * @see https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight
+ */
 export const fontWeight = {
   regular: 400,
   medium: 500,

--- a/packages/tokens/src/fonts.ts
+++ b/packages/tokens/src/fonts.ts
@@ -16,6 +16,8 @@ export const fontWeight = {
   medium: 500,
   semiBold: 600,
   bold: 700,
+  extraBold: 800,
+  black: 900,
 } as const;
 
 export const lineHeight = {


### PR DESCRIPTION
Added `extraBold` (800) and `black` (900) weights to the `fontWeight` object. This change extends support for additional font-weight values as defined in the CSS `font-weight` specification.

### Changes
- Added `extraBold: 800` and `black: 900` to the `fontWeight` object.
- Reference: [MDN Web Docs - font-weight](https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight)



## Visuals
<!-- If there are any screenshots or visual materials, please attach them. -->

## Checklist
- [ ] Have you written the functional specifications?
- [ ] Have you written the test code?

## Additional Discussion Points
<!-- If there are any additional points to be aware of, please specify them. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 폰트 가중치에 `extraBold(800)` 및 `black(900)` 속성 추가
	- 폰트 가중치에 대한 문서 주석 포함

<!-- end of auto-generated comment: release notes by coderabbit.ai -->