### PR TITLE
fix(github): correct wrong isse template format

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,7 @@
+---
 name: "Bug Report"
 about: "Report a bug"
-
+labels: "bug"
 ---
 
 ## Bug Description

--- a/.github/ISSUE_TEMPLATE/component_design.md
+++ b/.github/ISSUE_TEMPLATE/component_design.md
@@ -1,6 +1,7 @@
+---
 name: "Component Design"
 about: "Define and design a new component"
-
+labels: "enhancement"
 ---
 
 ## Component Function Definition

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
       "biome lint --write",
       "eslint --fix --flag unstable_ts_config"
     ],
-    "*.{json,css,md,yml,yaml}": ["biome format --write", "biome lint --write"]
+    "*.{json,css,yml,yaml}": ["biome format --write", "biome lint --write"]
   },
   "config": {
     "commitizen": {


### PR DESCRIPTION
## Changes

Issue template이 잘못된 형식으로 작성되어 있는 것 같습니다. 

## Visuals

|AS-IS|TO-BE|
|:-:|:-:|
|![image](https://github.com/user-attachments/assets/b758b84f-9ccd-4e97-9807-2da08989e974)|![image](https://github.com/user-attachments/assets/bde47429-c682-4de5-b080-6035d5e76578)|

## Checklist
- [ ] Have you written the functional specifications?
- [ ] Have you written the test code?

## Additional Discussion Points
<!-- If there are any additional points to be aware of, please specify them. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **문서**
	- 버그 보고서 템플릿에 메타데이터 추가
	- 컴포넌트 설계 이슈 템플릿 생성
	- 메타데이터에 이름, 설명, 레이블 포함

- **구성**
	- `lint-staged` 구성에서 Markdown 파일 제외

<!-- end of auto-generated comment: release notes by coderabbit.ai -->