### PR TITLE
Chore/readme update

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -17,5 +17,5 @@ export default {
   },
   managerHead: (head) =>
     `${head}
-<link rel="shortcut icon" href="../public/assets/favicon.ico" type="image/ico">`,
+<link rel="shortcut icon" href="https://github.com/sipe-team/3-2_side/raw/main/public/assets/favicon.ico" type="image/ico">`,
 } satisfies StorybookConfig;

--- a/.storybook/manager.ts
+++ b/.storybook/manager.ts
@@ -5,7 +5,7 @@ addons.setConfig({
   theme: create({
     base: 'dark',
     brandTitle: 'Sipe Design System',
-    brandImage: '../public/assets/sipe_brand_logo.png',
+    brandImage: 'https://github.com/sipe-team/3-2_side/raw/main/public/assets/sipe_brand_logo.png',
     brandUrl: 'https://sipe.team/',
     brandTarget: '_self',
     textColor: '#999999',

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![](./public/assets/og-image.png)
 
 # Sipe Design System 
-[![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/sipe-team/3-2_side/blob/main/LICENSE) ![Package Manager](https://img.shields.io/badge/pnpm-9.7.1-orange?logo=pnpm) [![Storybook](https://img.shields.io/badge/Storybook-8.4.5-ff4785?logo=storybook)](https://67417e47644abe8d4e63f82f-xvhdismwhu.chromatic.com/?path=/story/input--default) ![Tests](https://img.shields.io/badge/Vitest-2.1.4-green?logo=vitest) [![codecov](https://codecov.io/github/sipe-team/3-2_side/graph/badge.svg?token=1TNLVUFPXC)](https://codecov.io/github/sipe-team/3-2_side) <img alt="Github Stars" src="https://badgen.net/github/stars/sipe-team/3-2_side" /> 
+[![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/sipe-team/3-2_side/blob/main/LICENSE) ![Package Manager](https://img.shields.io/badge/pnpm-9.7.1-orange?logo=pnpm) [![Storybook](https://img.shields.io/badge/Storybook-8.4.7-ff4785?logo=storybook)](https://67417e47644abe8d4e63f82f-ggwavglffa.chromatic.com) ![Tests](https://img.shields.io/badge/Vitest-2.1.4-green?logo=vitest) [![codecov](https://codecov.io/gh/sipe-team/3-2_side/branch/changeset-release%2Fmain/graph/badge.svg?token=1TNLVUFPXC)](https://codecov.io/gh/sipe-team/3-2_side) <img alt="Github Stars" src="https://badgen.net/github/stars/sipe-team/3-2_side" /> 
 
 Sipe Design System is a monorepo-based component library built to modernize and standardize the official Sipe website. Drawing inspiration from our existing design patterns, we're creating a robust, type-safe, and accessible component system that can be used across all Sipe projects.
 

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -19,7 +19,7 @@ import { Meta } from '@storybook/addon-docs';
 
   <div style={{ display: 'flex', justifyContent: 'center' }}>
     <img 
-      src="../public/assets/og-image.png" 
+      src="https://github.com/sipe-team/3-2_side/raw/main/public/assets/og-image.png" 
       alt="Sipe Design System Logo" 
       style={{ 
         maxWidth: '100%',

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
       "biome lint --write",
       "eslint --fix --flag unstable_ts_config"
     ],
-    "*.{json,css,md,yml,yaml}": ["biome format --write", "biome lint --write"]
+    "*.{json,css,yml,yaml}": ["biome format --write", "biome lint --write"]
   },
   "config": {
     "commitizen": {


### PR DESCRIPTION
## Changes

-  Codecov 잘못된 링크 수정 
- Storybook 버전 수정 


- 스토리북 
  - asset   URL(../public/asset/*.png) 
                  ⬇️
  - remote URL(https://github.com/sipe-team/3-2_side/raw/main/public/assets/*.png)


## Visuals

|AS-IS|TO-BE|
|:-:|:-:|
|<img width="701" alt="image" src="https://github.com/user-attachments/assets/9d79120b-4580-4fcd-a82c-947e5a3ca590" />|![image](https://github.com/user-attachments/assets/18754e6b-0ef6-47a0-a740-55c38908fcf2)|



## Checklist
- [ ] Have you written the functional specifications?
- [ ] Have you written the test code?

## Additional Discussion Points

Readme 같은 부분은 추후 주기적으로 동기화하는 작업을 추가해야할 것 같음.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **문서**
	- Storybook 배지 버전을 8.4.5에서 8.4.7로 업데이트
	- Codecov 배지 URL을 변경하여 다른 브랜치의 커버리지 정보 표시

- **스타일**
	- Storybook의 파비콘과 브랜드 로고를 로컬 파일에서 GitHub 호스팅 URL로 변경
	- 문서 내 이미지 소스를 로컬 경로에서 GitHub 호스팅 URL로 업데이트

- **기타**
	- lint-staged 구성에서 Markdown 파일 포맷팅 제외

<!-- end of auto-generated comment: release notes by coderabbit.ai -->