### PR TITLE
refactor(card): add custom ratio for better flexibility

### DIFF
--- a/.changeset/eighty-apricots-punch.md
+++ b/.changeset/eighty-apricots-punch.md
@@ -1,0 +1,5 @@
+---
+"@sipe-team/card": minor
+---
+
+add custom ratio in card component

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![](./public/assets/og-image.png)
 
 # Sipe Design System 
-[![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/sipe-team/3-2_side/blob/main/LICENSE) ![Package Manager](https://img.shields.io/badge/pnpm-9.7.1-orange?logo=pnpm) [![Storybook](https://img.shields.io/badge/Storybook-8.4.7-ff4785?logo=storybook)](https://67417e47644abe8d4e63f82f-ggwavglffa.chromatic.com) ![Tests](https://img.shields.io/badge/Vitest-2.1.4-green?logo=vitest) [![codecov](https://codecov.io/gh/sipe-team/3-2_side/branch/changeset-release%2Fmain/graph/badge.svg?token=1TNLVUFPXC)](https://codecov.io/gh/sipe-team/3-2_side) <img alt="Github Stars" src="https://badgen.net/github/stars/sipe-team/3-2_side" /> 
+[![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/sipe-team/3-2_side/blob/main/LICENSE) ![Package Manager](https://img.shields.io/badge/pnpm-9.7.1-orange?logo=pnpm) [![Storybook](https://img.shields.io/badge/Storybook-8.4.7-ff4785?logo=storybook)](https://67417e47644abe8d4e63f82f-lynsfaiqst.chromatic.com) ![Tests](https://img.shields.io/badge/Vitest-2.1.4-green?logo=vitest) [![codecov](https://codecov.io/gh/sipe-team/3-2_side/branch/changeset-release%2Fmain/graph/badge.svg?token=1TNLVUFPXC)](https://codecov.io/gh/sipe-team/3-2_side) <img alt="Github Stars" src="https://badgen.net/github/stars/sipe-team/3-2_side" /> 
 
 Sipe Design System is a monorepo-based component library built to modernize and standardize the official Sipe website. Drawing inspiration from our existing design patterns, we're creating a robust, type-safe, and accessible component system that can be used across all Sipe projects.
 

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
       "biome lint --write",
       "eslint --fix --flag unstable_ts_config"
     ],
-    "*.{json,css,md,yml,yaml}": ["biome format --write", "biome lint --write"]
+    "*.{json,css,yml,yaml}": ["biome format --write", "biome lint --write"]
   },
   "config": {
     "commitizen": {

--- a/packages/card/src/Card.stories.tsx
+++ b/packages/card/src/Card.stories.tsx
@@ -15,7 +15,7 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     children: <span style={{ fontSize: '20px' }}>Card</span>,
-    ratio: 'rectangle',
+    ratio: 'portrait',
     variant: 'filled',
   },
 };

--- a/packages/card/src/Card.stories.tsx
+++ b/packages/card/src/Card.stories.tsx
@@ -7,6 +7,16 @@ const meta = {
   parameters: {
     layout: 'centered',
   },
+  argTypes: {
+    ratio: {
+      control: 'select',
+      options: ['rectangle', 'square', 'wide', 'portrait', 'auto'],
+    },
+    variant: {
+      control: 'select',
+      options: ['filled', 'outline'],
+    },
+  },
 } satisfies Meta<typeof Card>;
 export default meta;
 
@@ -15,7 +25,6 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     children: <span style={{ fontSize: '20px' }}>Card</span>,
-    ratio: 'portrait',
     variant: 'filled',
   },
 };

--- a/packages/card/src/Card.test.tsx
+++ b/packages/card/src/Card.test.tsx
@@ -37,6 +37,21 @@ test('ratio에 wide로 넣으면 aspect-ratio는 21/9로 반환한다.', () => {
   expect(screen.getByText('Card')).toHaveStyle('aspect-ratio: 21 / 9');
 });
 
+test('ratio에 square로 넣으면 aspect-ratio는 1/1로 반환한다.', () => {
+  render(<Card ratio="square">Card</Card>);
+  expect(screen.getByText('Card')).toHaveStyle('aspect-ratio: 1 / 1');
+});
+
+test('ratio에 portrait로 넣으면 aspect-ratio는 3/4로 반환한다.', () => {
+  render(<Card ratio="portrait">Card</Card>);
+  expect(screen.getByText('Card')).toHaveStyle('aspect-ratio: 3 / 4');
+});
+
+test('ratio에 auto로 넣으면 aspect-ratio는 auto로 반환한다.', () => {
+  render(<Card ratio="auto">Card</Card>);
+  expect(screen.getByText('Card')).toHaveStyle('aspect-ratio: auto');
+});
+
 test('variant는 default로 filled를 적용한다.', () => {
   render(<Card>Card</Card>);
   expect(screen.getByText('Card')).toHaveStyle({
@@ -48,5 +63,19 @@ test(`variant가 outline으로 넣으면 border(${color.cyan300}) 색상을 적�
   render(<Card variant="outline">Card</Card>);
   expect(screen.getByText('Card')).toHaveStyle({
     border: `1px solid ${color.cyan300}`,
+  });
+});
+
+test(`variant가 filled일 때 배경색이 ${color.gray100}이다.`, () => {
+  render(<Card variant="filled">Card</Card>);
+  expect(screen.getByText('Card')).toHaveStyle({
+    backgroundColor: color.gray100,
+  });
+});
+
+test(`variant가 outline일 때 배경색이 ${color.gray50}이다.`, () => {
+  render(<Card variant="outline">Card</Card>);
+  expect(screen.getByText('Card')).toHaveStyle({
+    backgroundColor: color.gray50,
   });
 });

--- a/packages/card/src/Card.tsx
+++ b/packages/card/src/Card.tsx
@@ -21,7 +21,7 @@ export interface CardProps extends ComponentProps<'div'> {
 export const Card = forwardRef(function Card(
   {
     className,
-    ratio = 'rectangle',
+    ratio = 'custom',
     style: _style,
     variant = 'filled',
     asChild,
@@ -78,6 +78,6 @@ function getAspectRatio(ratio: CardRatio) {
     case 'custom':
       return 'auto';
     default:
-      return '16 / 9';
+      return 'auto';
   }
 }

--- a/packages/card/src/Card.tsx
+++ b/packages/card/src/Card.tsx
@@ -9,7 +9,7 @@ import {
 } from 'react';
 import styles from './Card.module.css';
 
-export type CardRatio = 'rectangle' | 'square' | 'wide' | 'portrait';
+export type CardRatio = 'rectangle' | 'square' | 'wide' | 'portrait' | 'custom';
 export type CardVariant = 'filled' | 'outline';
 
 export interface CardProps extends ComponentProps<'div'> {
@@ -75,6 +75,8 @@ function getAspectRatio(ratio: CardRatio) {
       return '21 / 9';
     case 'portrait':
       return '3 / 4';
+    case 'custom':
+      return 'auto';
     default:
       return '16 / 9';
   }

--- a/packages/card/src/Card.tsx
+++ b/packages/card/src/Card.tsx
@@ -9,7 +9,7 @@ import {
 } from 'react';
 import styles from './Card.module.css';
 
-export type CardRatio = 'rectangle' | 'square' | 'wide' | 'portrait' | 'custom';
+export type CardRatio = 'rectangle' | 'square' | 'wide' | 'portrait' | 'auto';
 export type CardVariant = 'filled' | 'outline';
 
 export interface CardProps extends ComponentProps<'div'> {
@@ -21,7 +21,7 @@ export interface CardProps extends ComponentProps<'div'> {
 export const Card = forwardRef(function Card(
   {
     className,
-    ratio = 'custom',
+    ratio = 'rectangle',
     style: _style,
     variant = 'filled',
     asChild,
@@ -75,8 +75,6 @@ function getAspectRatio(ratio: CardRatio) {
       return '21 / 9';
     case 'portrait':
       return '3 / 4';
-    case 'custom':
-      return 'auto';
     default:
       return 'auto';
   }


### PR DESCRIPTION
## Changes

- https://sipe-team.slack.com/archives/C08630E97AQ/p1736429832245539

기존에 반드시 `aspect-ratio`가 default로 들어가는 문제가 있어서 사용자가 Card 컴포넌트로 UI를 좀 더 유연하게 구현하기 힘들다는 피드백이 있어서 이에 수정합니다. 

```ts
export type CardRatio = 'rectangle' | 'square' | 'wide' | 'portrait' | 'auto';

function getAspectRatio(ratio: CardRatio) {
  switch (ratio) {
    case 'square':
      return '1 / 1';
    case 'rectangle':
      return '16 / 9';
    case 'wide':
      return '21 / 9';
    case 'portrait':
      return '3 / 4';
    default:
      return 'auto';
  }
}
```

## Visuals

## Checklist
- [ ] Have you written the functional specifications?
- [ ] Have you written the test code?

## Additional Discussion Points
<!-- If there are any additional points to be aware of, please specify them. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- 카드 컴포넌트에 사용자 정의 비율 옵션 추가
	- 카드의 레이아웃 유연성 향상

- **변경 사항**
	- 기본 카드 비율을 'rectangle'에서 'auto'로 변경
	- 새로운 카드 비율 유형 'auto' 도입
	- 가로세로 비율 계산 로직 업데이트

- **테스트**
	- 카드 컴포넌트의 비율 및 변형 속성에 대한 새로운 테스트 케이스 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->