### PR TITLE
feat(checkbox): Checkbox 컴포넌트 구현

### DIFF
--- a/packages/checkbox/.storybook/main.ts
+++ b/packages/checkbox/.storybook/main.ts
@@ -1,0 +1,15 @@
+import type { StorybookConfig } from '@storybook/react-vite';
+
+export default {
+  stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
+  addons: [
+    '@storybook/addon-onboarding',
+    '@storybook/addon-links',
+    '@storybook/addon-essentials',
+    '@storybook/addon-interactions',
+  ],
+  framework: {
+    name: '@storybook/react-vite',
+    options: {},
+  },
+} satisfies StorybookConfig;

--- a/packages/checkbox/.storybook/preview.ts
+++ b/packages/checkbox/.storybook/preview.ts
@@ -1,0 +1,16 @@
+import type { Preview } from '@storybook/react';
+import 'sanitize.css';
+
+const preview: Preview = {
+  parameters: {
+    actions: { argTypesRegex: '^on[A-Z].*' },
+    controls: {
+      matchers: {
+        color: /(background|color)$/i,
+        date: /Date$/i,
+      },
+    },
+  },
+};
+
+export default preview;

--- a/packages/checkbox/.storybook/preview.ts
+++ b/packages/checkbox/.storybook/preview.ts
@@ -14,3 +14,4 @@ const preview: Preview = {
 };
 
 export default preview;
+

--- a/packages/checkbox/global.d.ts
+++ b/packages/checkbox/global.d.ts
@@ -1,0 +1,1 @@
+declare module '*.module.css';

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -1,0 +1,71 @@
+{
+  "name": "@sipe-team/checkbox",
+  "description": "Checkbox for Sipe Design System",
+  "version": "0.0.0",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sipe-team/3-2_side"
+  },
+  "type": "module",
+  "exports": "./src/index.ts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsup",
+    "build:storybook": "storybook build",
+    "dev:storybook": "storybook dev -p 6006",
+    "lint:biome": "pnpm exec biome lint",
+    "lint:eslint": "pnpm exec eslint --flag unstable_ts_config",
+    "test": "vitest",
+    "typecheck": "tsc",
+    "prepack": "pnpm run build"
+  },
+  "dependencies": {
+    "@radix-ui/react-checkbox": "^1.0.4",
+    "@radix-ui/react-slot": "^1.0.2",
+    "@sipe-team/tokens": "workspace:^",
+    "@sipe-team/typography": "workspace:^",
+    "clsx": "^2.1.1",
+    "lucide-react": "^0.344.0"
+  },
+  "devDependencies": {
+    "@storybook/addon-essentials": "catalog:",
+    "@storybook/addon-interactions": "catalog:",
+    "@storybook/addon-links": "catalog:",
+    "@storybook/blocks": "catalog:",
+    "@storybook/react": "catalog:",
+    "@storybook/react-vite": "catalog:",
+    "@storybook/test": "catalog:",
+    "@testing-library/jest-dom": "catalog:",
+    "@testing-library/react": "catalog:",
+    "@testing-library/user-event": "^14.5.2",
+    "@types/react": "^18.3.12",
+    "happy-dom": "catalog:",
+    "react": "^18.3.1",
+    "storybook": "catalog:",
+    "tsup": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "peerDependencies": {
+    "react": ">= 18"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://npm.pkg.github.com",
+    "exports": {
+      ".": {
+        "import": {
+          "types": "./dist/index.d.ts",
+          "default": "./dist/index.js"
+        },
+        "require": {
+          "types": "./dist/index.d.cts",
+          "default": "./dist/index.cjs"
+        }
+      },
+      "./styles.css": "./dist/index.css"
+    }
+  },
+  "sideEffects": false
+}

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -22,7 +22,6 @@
   },
   "dependencies": {
     "@radix-ui/react-checkbox": "^1.0.4",
-    "@radix-ui/react-slot": "^1.0.2",
     "@sipe-team/tokens": "workspace:^",
     "@sipe-team/typography": "workspace:^",
     "clsx": "^2.1.1",

--- a/packages/checkbox/src/Checkbox.module.css
+++ b/packages/checkbox/src/Checkbox.module.css
@@ -3,22 +3,22 @@
   display: flex;
   align-items: center;
   gap: var(--padding);
+  margin: 4px;
 }
 
 .label {
   display: flex;
   align-items: center;
   gap: var(--padding);
-  margin-left: var(--margin);
 }
 
 .checkbox {
   all: unset;
   width: var(--size);
   height: var(--size);
-  border-radius: var(--border-radius);
-  border: 2px solid var(--border-color);
-  background-color: var(--background-color);
+  border-radius: 4px;
+  border: 2px solid #a1a1aa;
+  background-color: #ffffff;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -26,7 +26,7 @@
 }
 
 .checkbox:focus-visible {
-  border-color: var(--focus-border-color);
+  border-color: #06b6d4;
   outline: none;
 }
 
@@ -36,12 +36,12 @@
 }
 
 .checkbox[data-state="checked"] {
-  border-color: var(--checked-border-color);
-  background-color: var(--checked-background-color);
+  border-color: #00ffff;
+  background-color: #00ffff;
 }
 
 .indicator {
-  color: var(--indicator-color);
+  color: #ffffff;
   height: var(--indicator-size);
   width: var(--indicator-size);
   display: flex;

--- a/packages/checkbox/src/Checkbox.module.css
+++ b/packages/checkbox/src/Checkbox.module.css
@@ -1,0 +1,52 @@
+.root {
+  all: unset;
+  display: flex;
+  align-items: center;
+  gap: var(--padding);
+}
+
+.label {
+  display: flex;
+  align-items: center;
+  gap: var(--padding);
+  margin-left: var(--margin);
+}
+
+.checkbox {
+  all: unset;
+  width: var(--size);
+  height: var(--size);
+  border-radius: 4px;
+  border: 2px solid var(--border-color);
+  background-color: var(--background-color);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.checkbox[data-disabled] {
+  cursor: not-allowed;
+  opacity: 0.4;
+}
+
+.checkbox[data-state="checked"] {
+  border-color: var(--checked-border-color);
+  background-color: var(--checked-background-color);
+}
+
+.indicator {
+  color: var(--indicator-color);
+  height: var(--indicator-size);
+  width: var(--indicator-size);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 0;
+}
+
+.group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}

--- a/packages/checkbox/src/Checkbox.module.css
+++ b/packages/checkbox/src/Checkbox.module.css
@@ -25,6 +25,11 @@
   cursor: pointer;
 }
 
+.checkbox:focus-visible {
+  border-color: var(--focus-border-color);
+  outline: none;
+}
+
 .checkbox[data-disabled] {
   cursor: not-allowed;
   opacity: 0.4;

--- a/packages/checkbox/src/Checkbox.module.css
+++ b/packages/checkbox/src/Checkbox.module.css
@@ -16,7 +16,7 @@
   all: unset;
   width: var(--size);
   height: var(--size);
-  border-radius: 4px;
+  border-radius: var(--border-radius);
   border: 2px solid var(--border-color);
   background-color: var(--background-color);
   display: flex;

--- a/packages/checkbox/src/Checkbox.stories.tsx
+++ b/packages/checkbox/src/Checkbox.stories.tsx
@@ -1,0 +1,102 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import { Checkbox, CheckboxGroup } from './Checkbox';
+
+const meta = {
+    title: 'Components/Checkbox',
+    component: Checkbox,
+    parameters: {
+        layout: 'centered',
+    },
+    argTypes: {
+        size: {
+            description: '체크박스의 크기를 지정합니다',
+            options: ['sm', 'md', 'lg'],
+            control: { type: 'radio' },
+        },
+        disabled: {
+            description: '체크박스의 비활성화 상태를 지정합니다',
+            control: { type: 'boolean' },
+        },
+        checked: {
+            description: '체크박스의 선택 상태를 지정합니다',
+            control: { type: 'boolean' },
+        },
+        label: {
+            description: '체크박스의 레이블을 지정합니다',
+            control: 'text',
+        },
+    },
+} satisfies Meta<typeof Checkbox>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {
+    args: {
+        label: '체크박스',
+        size: 'md',
+    },
+};
+
+export const Sizes: Story = {
+    args: {
+        label: '체크박스',
+    },
+    render: (args) => (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
+            <Checkbox {...args} size="sm" label="Small" />
+            <Checkbox {...args} size="md" label="Medium (Default)" />
+            <Checkbox {...args} size="lg" label="Large" />
+        </div>
+    ),
+};
+
+export const States: Story = {
+    args: {
+        label: '체크박스',
+    },
+    render: (args) => (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
+            <Checkbox {...args} label="Unchecked (Default)" />
+            <Checkbox {...args} label="Checked" defaultChecked />
+            <Checkbox {...args} label="Disabled" disabled />
+            <Checkbox {...args} label="Disabled & Checked" disabled defaultChecked />
+        </div>
+    ),
+};
+
+export const Controlled: Story = {
+    args: {
+        label: 'Controlled Checkbox',
+    },
+    render: (args) => {
+        const [checked, setChecked] = useState<boolean | 'indeterminate'>(false);
+
+        return (
+            <Checkbox
+                {...args}
+                checked={checked}
+                onCheckedChange={(state) => setChecked(state)}
+            />
+        );
+    },
+};
+
+export const Group: Story = {
+    args: {
+        size: 'md',
+    },
+    render: (args) => {
+        const [selected, setSelected] = useState<string[]>([]);
+
+        return (
+            <CheckboxGroup value={selected} onChange={setSelected}>
+                <Checkbox {...args} value="apple" label="사과" />
+                <Checkbox {...args} value="banana" label="바나나" />
+                <Checkbox {...args} value="orange" label="오렌지" />
+            </CheckboxGroup>
+        );
+    },
+};

--- a/packages/checkbox/src/Checkbox.test.tsx
+++ b/packages/checkbox/src/Checkbox.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { expect, test } from 'vitest';
+import { useState } from 'react';
+import { Checkbox, CheckboxGroup } from './Checkbox';
+
+test('체크박스를 클릭하면 상태가 변경된다.', async () => {
+    const user = userEvent.setup();
+    render(<Checkbox label="테스트" />);
+
+    const checkbox = screen.getByRole('checkbox', { name: '테스트' });
+    expect(checkbox).not.toBeChecked();
+
+    await user.click(checkbox);
+    expect(checkbox).toBeChecked();
+});
+
+test('disabled 상태의 체크박스는 클릭할 수 없다.', async () => {
+    const user = userEvent.setup();
+    render(<Checkbox disabled label="테스트" />);
+
+    const checkbox = screen.getByRole('checkbox', { name: '테스트' });
+    expect(checkbox).toBeDisabled();
+
+    await user.click(checkbox);
+    expect(checkbox).not.toBeChecked();
+});
+
+test('size를 주입하지 않으면 기본값 md로 설정된다.', () => {
+    render(<Checkbox label="테스트" />);
+
+    const checkbox = screen.getByRole('checkbox');
+    expect(checkbox).toHaveStyle({ width: '20px', height: '20px' });
+});
+
+test.each([
+    { size: 'sm', expected: '16px' },
+    { size: 'md', expected: '20px' },
+    { size: 'lg', expected: '24px' },
+] as const)('size가 $size일 때 체크박스 크기가 $expected로 설정된다.', ({ size, expected }) => {
+    render(<Checkbox size={size} label="테스트" />);
+
+    const checkbox = screen.getByRole('checkbox');
+    expect(checkbox).toHaveStyle({ width: expected, height: expected });
+});
+
+test('체크박스 그룹에서 여러 항목을 선택할 수 있다.', async () => {
+    const user = userEvent.setup();
+
+    const TestComponent = () => {
+        const [selected, setSelected] = useState<string[]>([]);
+        return (
+            <CheckboxGroup value={selected} onChange={setSelected}>
+                <Checkbox value="1" label="항목 1" />
+                <Checkbox value="2" label="항목 2" />
+                <Checkbox value="3" label="항목 3" />
+            </CheckboxGroup>
+        );
+    };
+
+    render(<TestComponent />);
+
+    const checkbox1 = screen.getByRole('checkbox', { name: '항목 1' });
+    const checkbox2 = screen.getByRole('checkbox', { name: '항목 2' });
+
+    await user.click(checkbox1);
+    expect(checkbox1).toBeChecked();
+    expect(checkbox2).not.toBeChecked();
+
+    await user.click(checkbox2);
+    expect(checkbox1).toBeChecked();
+    expect(checkbox2).toBeChecked();
+
+    await user.click(checkbox1);
+    expect(checkbox1).not.toBeChecked();
+    expect(checkbox2).toBeChecked();
+});
+
+test('체크박스 그룹에서 value prop으로 선택된 항목을 제어할 수 있다.', async () => {
+    const selectedValues = ['1', '3'];
+
+    render(
+        <CheckboxGroup value={selectedValues}>
+            <Checkbox value="1" label="항목 1" />
+            <Checkbox value="2" label="항목 2" />
+            <Checkbox value="3" label="항목 3" />
+        </CheckboxGroup>
+    );
+
+    const checkbox1 = screen.getByRole('checkbox', { name: '항목 1' });
+    const checkbox2 = screen.getByRole('checkbox', { name: '항목 2' });
+    const checkbox3 = screen.getByRole('checkbox', { name: '항목 3' });
+
+    expect(checkbox1).toHaveAttribute('data-state', 'checked');
+    expect(checkbox2).toHaveAttribute('data-state', 'unchecked');
+    expect(checkbox3).toHaveAttribute('data-state', 'checked');
+});

--- a/packages/checkbox/src/Checkbox.test.tsx
+++ b/packages/checkbox/src/Checkbox.test.tsx
@@ -4,7 +4,7 @@ import { expect, test } from 'vitest';
 import { useState } from 'react';
 import { Checkbox, CheckboxGroup } from './Checkbox';
 
-test('체크박스를 클릭하면 상태가 변경된다.', async () => {
+test('체크박스를 클릭하면 체크 상태가 활성화된다.', async () => {
     const user = userEvent.setup();
     render(<Checkbox label="테스트" />);
 
@@ -15,7 +15,7 @@ test('체크박스를 클릭하면 상태가 변경된다.', async () => {
     expect(checkbox).toBeChecked();
 });
 
-test('disabled 상태의 체크박스는 클릭할 수 없다.', async () => {
+test('disabled 상태의 체크박스를 클릭해도 체크 상태가 바뀌지 않는다.', async () => {
     const user = userEvent.setup();
     render(<Checkbox disabled label="테스트" />);
 

--- a/packages/checkbox/src/Checkbox.test.tsx
+++ b/packages/checkbox/src/Checkbox.test.tsx
@@ -91,7 +91,7 @@ test('체크박스 그룹에서 value prop으로 선택된 항목을 제어할 �
     const checkbox2 = screen.getByRole('checkbox', { name: '항목 2' });
     const checkbox3 = screen.getByRole('checkbox', { name: '항목 3' });
 
-    expect(checkbox1).toHaveAttribute('data-state', 'checked');
-    expect(checkbox2).toHaveAttribute('data-state', 'unchecked');
-    expect(checkbox3).toHaveAttribute('data-state', 'checked');
+    expect(checkbox1).toBeChecked();
+    expect(checkbox2).not.toBeChecked();
+    expect(checkbox3).toBeChecked();
 });

--- a/packages/checkbox/src/Checkbox.tsx
+++ b/packages/checkbox/src/Checkbox.tsx
@@ -62,6 +62,7 @@ export const Checkbox = forwardRef<
           style={
             {
               '--margin': '4px',
+              '--border-radius': '4px',
               '--padding': padding,
               '--size': checkboxSize,
               '--indicator-size': indicatorSize,

--- a/packages/checkbox/src/Checkbox.tsx
+++ b/packages/checkbox/src/Checkbox.tsx
@@ -1,0 +1,131 @@
+import * as CheckboxPrimitive from '@radix-ui/react-checkbox';
+import { color, fontSize } from '@sipe-team/tokens';
+import { Typography } from '@sipe-team/typography';
+import { Check } from 'lucide-react';
+import { type ComponentPropsWithoutRef, type ElementRef, forwardRef, useId, Children, isValidElement, cloneElement } from 'react';
+import styles from './Checkbox.module.css';
+
+export type CheckboxSize = 'sm' | 'md' | 'lg';
+
+export interface CheckboxProps
+    extends Omit<ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>, 'asChild'> {
+  label?: string;
+  size?: CheckboxSize;
+}
+
+export interface CheckboxGroupProps {
+  children: React.ReactNode;
+  defaultValue?: string[];
+  name?: string;
+  onChange?: (value: string[]) => void;
+  value?: string[];
+}
+
+const getSizeStyles = (size: CheckboxSize) => {
+  switch (size) {
+    case 'sm':
+      return {
+        checkboxSize: '16px',
+        indicatorSize: '12px',
+        fontSize: fontSize[12],
+        padding: '4px',
+      };
+    case 'lg':
+      return {
+        checkboxSize: '24px',
+        indicatorSize: '18px',
+        fontSize: fontSize[16],
+        padding: '8px',
+      };
+    default:
+      return {
+        checkboxSize: '20px',
+        indicatorSize: '14px',
+        fontSize: fontSize[14],
+        padding: '6px',
+      };
+  }
+};
+
+export const Checkbox = forwardRef<
+    ElementRef<typeof CheckboxPrimitive.Root>,
+    CheckboxProps
+>(({ className, size = 'md', label, style, id: providedId, ...props }, ref) => {
+  const generatedId = useId();
+  const id = providedId || generatedId;
+  const { checkboxSize, indicatorSize, fontSize, padding } = getSizeStyles(size);
+
+  return (
+      <div
+          className={styles.root}
+          style={
+            {
+              '--margin': '4px',
+              '--padding': padding,
+              '--size': checkboxSize,
+              '--indicator-size': indicatorSize,
+              '--border-color': color.gray400,
+              '--background-color': color.white,
+              '--checked-border-color': color.cyan300,
+              '--checked-background-color': color.cyan300,
+              '--indicator-color': color.white,
+              ...style,
+            } as React.CSSProperties
+          }
+      >
+        <CheckboxPrimitive.Root
+            className={styles.checkbox}
+            ref={ref}
+            id={id}
+            {...props}
+        >
+          <CheckboxPrimitive.Indicator className={styles.indicator}>
+            <Check size={indicatorSize} />
+          </CheckboxPrimitive.Indicator>
+        </CheckboxPrimitive.Root>
+        {label && (
+            <Typography asChild size={fontSize}>
+              <label htmlFor={id} className={styles.label}>
+                {label}
+              </label>
+            </Typography>
+        )}
+      </div>
+  );
+});
+
+Checkbox.displayName = 'Checkbox';
+
+export const CheckboxGroup = forwardRef<HTMLDivElement, CheckboxGroupProps>(
+    ({ children, name, onChange, value }, ref) => {
+      const handleCheckedChange = (checked: boolean, itemValue: string | undefined) => {
+        if (!onChange || !itemValue) return;
+
+        const newValues = checked
+            ? [...(value || []), itemValue]
+            : (value || []).filter((v) => v !== itemValue);
+
+        onChange(newValues);
+      };
+
+      const mappedChildren = Children.map(children, (child) => {
+        if (!isValidElement(child)) return child;
+
+        const checked = value?.includes(child.props.value);
+
+        return cloneElement(child, {
+          checked,
+          name,
+          onCheckedChange: (checked: boolean) => handleCheckedChange(checked, child.props.value),
+        });
+      });
+
+      return (
+          <div className={styles.group} ref={ref}>
+            {mappedChildren}
+          </div>
+      );
+    }
+);
+
+CheckboxGroup.displayName = 'CheckboxGroup';

--- a/packages/checkbox/src/Checkbox.tsx
+++ b/packages/checkbox/src/Checkbox.tsx
@@ -2,7 +2,17 @@ import * as CheckboxPrimitive from '@radix-ui/react-checkbox';
 import { fontSize } from '@sipe-team/tokens';
 import { Typography } from '@sipe-team/typography';
 import { Check } from 'lucide-react';
-import { type ComponentPropsWithoutRef, type ElementRef, forwardRef, useId, Children, isValidElement, cloneElement } from 'react';
+import {
+  type ComponentPropsWithoutRef,
+  type ElementRef,
+  type ReactNode,
+  type CSSProperties,
+  Children,
+  cloneElement,
+  forwardRef,
+  isValidElement,
+  useId,
+} from 'react';
 import styles from './Checkbox.module.css';
 
 export type CheckboxSize = 'sm' | 'md' | 'lg';
@@ -15,7 +25,7 @@ export interface CheckboxProps
 }
 
 export interface CheckboxGroupProps {
-  children: React.ReactNode;
+  children: ReactNode;
   defaultValue?: string[];
   name?: string;
   onChange?: (value: string[]) => void;
@@ -53,38 +63,31 @@ export const Checkbox = forwardRef<
     CheckboxProps
 >(({ className, size = 'md', label, style, id: providedId, ...props }, ref) => {
   const generatedId = useId();
-  const id = providedId || generatedId;
+  const id = providedId ?? generatedId;
   const { checkboxSize, indicatorSize, fontSize, padding } = getSizeStyles(size);
 
   return (
       <div
           className={styles.root}
-          style={
-            {
-              '--padding': padding,
-              '--size': checkboxSize,
-              '--indicator-size': indicatorSize,
-              ...style,
-            } as React.CSSProperties
-          }
+          style={{
+            '--padding': padding,
+            '--size': checkboxSize,
+            '--indicator-size': indicatorSize,
+            ...style,
+          } as CSSProperties}
       >
-        <CheckboxPrimitive.Root
-            className={styles.checkbox}
-            ref={ref}
-            id={id}
-            {...props}
-        >
+        <CheckboxPrimitive.Root className={styles.checkbox} ref={ref} id={id} {...props}>
           <CheckboxPrimitive.Indicator className={styles.indicator}>
             <Check size={indicatorSize} />
           </CheckboxPrimitive.Indicator>
         </CheckboxPrimitive.Root>
-        {label && (
+        {label ? (
             <Typography asChild size={fontSize}>
               <label htmlFor={id} className={styles.label}>
                 {label}
               </label>
             </Typography>
-        )}
+        ) : null}
       </div>
   );
 });
@@ -93,20 +96,27 @@ Checkbox.displayName = 'Checkbox';
 
 export const CheckboxGroup = forwardRef<HTMLDivElement, CheckboxGroupProps>(
     ({ children, name, onChange, value }, ref) => {
-      const handleCheckedChange = (checked: CheckboxPrimitive.CheckedState, itemValue: string | undefined) => {
-        if (!onChange || !itemValue || typeof checked !== 'boolean') return;
+      const handleCheckedChange = (
+          checked: CheckboxPrimitive.CheckedState,
+          itemValue: string | undefined,
+      ) => {
+        if (!onChange || !itemValue || typeof checked !== 'boolean') {
+          return;
+        }
 
         const newValues = checked
-            ? [...(value || []), itemValue]
-            : (value || []).filter((v) => v !== itemValue);
+            ? [...(value ?? []), itemValue]
+            : (value ?? []).filter((v) => v !== itemValue);
 
         onChange(newValues);
       };
 
       const mappedChildren = Children.map(children, (child) => {
-        if (!isValidElement<CheckboxProps>(child)) return child;
+        if (!isValidElement<CheckboxProps>(child)) {
+          return child;
+        }
 
-        const checked = value?.includes(child.props.value || '') || false;
+        const checked = value?.includes(child.props.value ?? '') ?? false;
 
         return cloneElement(child, {
           checked,
@@ -115,7 +125,7 @@ export const CheckboxGroup = forwardRef<HTMLDivElement, CheckboxGroupProps>(
             handleCheckedChange(state, child.props.value);
             child.props.onCheckedChange?.(state);
           },
-        } as Partial<CheckboxProps>);
+        });
       });
 
       return (
@@ -123,7 +133,7 @@ export const CheckboxGroup = forwardRef<HTMLDivElement, CheckboxGroupProps>(
             {mappedChildren}
           </div>
       );
-    }
+    },
 );
 
 CheckboxGroup.displayName = 'CheckboxGroup';

--- a/packages/checkbox/src/Checkbox.tsx
+++ b/packages/checkbox/src/Checkbox.tsx
@@ -1,5 +1,5 @@
 import * as CheckboxPrimitive from '@radix-ui/react-checkbox';
-import { color, fontSize } from '@sipe-team/tokens';
+import { fontSize } from '@sipe-team/tokens';
 import { Typography } from '@sipe-team/typography';
 import { Check } from 'lucide-react';
 import { type ComponentPropsWithoutRef, type ElementRef, forwardRef, useId, Children, isValidElement, cloneElement } from 'react';
@@ -61,17 +61,9 @@ export const Checkbox = forwardRef<
           className={styles.root}
           style={
             {
-              '--margin': '4px',
-              '--border-radius': '4px',
               '--padding': padding,
               '--size': checkboxSize,
               '--indicator-size': indicatorSize,
-              '--border-color': color.gray400,
-              '--background-color': color.white,
-              '--checked-border-color': color.cyan300,
-              '--checked-background-color': color.cyan300,
-              '--indicator-color': color.white,
-              '--focus-border-color': color.cyan500,
               ...style,
             } as React.CSSProperties
           }

--- a/packages/checkbox/src/Checkbox.tsx
+++ b/packages/checkbox/src/Checkbox.tsx
@@ -70,6 +70,7 @@ export const Checkbox = forwardRef<
               '--checked-border-color': color.cyan300,
               '--checked-background-color': color.cyan300,
               '--indicator-color': color.white,
+              '--focus-border-color': color.cyan500,
               ...style,
             } as React.CSSProperties
           }

--- a/packages/checkbox/src/index.ts
+++ b/packages/checkbox/src/index.ts
@@ -1,0 +1,1 @@
+export * from './Checkbox';

--- a/packages/checkbox/tsconfig.json
+++ b/packages/checkbox/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.json"
+}

--- a/packages/checkbox/tsup.config.ts
+++ b/packages/checkbox/tsup.config.ts
@@ -1,0 +1,3 @@
+import defaultConfig from '../../tsup.config';
+
+export default defaultConfig;

--- a/packages/checkbox/vitest.config.ts
+++ b/packages/checkbox/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineProject, mergeConfig } from 'vitest/config';
+import defaultConfig from '../../vitest.config';
+
+export default mergeConfig(
+  defaultConfig,
+  defineProject({
+    test: {
+      setupFiles: './vitest.setup.ts',
+    },
+  }),
+);

--- a/packages/checkbox/vitest.setup.ts
+++ b/packages/checkbox/vitest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -551,6 +551,79 @@ importers:
         specifier: 'catalog:'
         version: 2.1.8(@types/node@22.10.1)(happy-dom@15.11.7)
 
+  packages/checkbox:
+    dependencies:
+      '@radix-ui/react-checkbox':
+        specifier: ^1.0.4
+        version: 1.1.3(@types/react-dom@18.3.1)(@types/react@18.3.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot':
+        specifier: ^1.0.2
+        version: 1.1.0(@types/react@18.3.13)(react@18.3.1)
+      '@sipe-team/tokens':
+        specifier: workspace:^
+        version: link:../tokens
+      '@sipe-team/typography':
+        specifier: workspace:^
+        version: link:../typography
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
+      lucide-react:
+        specifier: ^0.344.0
+        version: 0.344.0(react@18.3.1)
+    devDependencies:
+      '@storybook/addon-essentials':
+        specifier: 'catalog:'
+        version: 8.4.6(@types/react@18.3.13)(storybook@8.4.7(prettier@2.8.8))
+      '@storybook/addon-interactions':
+        specifier: 'catalog:'
+        version: 8.4.6(storybook@8.4.7(prettier@2.8.8))
+      '@storybook/addon-links':
+        specifier: 'catalog:'
+        version: 8.4.6(react@18.3.1)(storybook@8.4.7(prettier@2.8.8))
+      '@storybook/blocks':
+        specifier: 'catalog:'
+        version: 8.4.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.7(prettier@2.8.8))
+      '@storybook/react':
+        specifier: 'catalog:'
+        version: 8.4.6(@storybook/test@8.4.6(storybook@8.4.7(prettier@2.8.8)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.7(prettier@2.8.8))(typescript@5.7.2)
+      '@storybook/react-vite':
+        specifier: 'catalog:'
+        version: 8.4.6(@storybook/test@8.4.6(storybook@8.4.7(prettier@2.8.8)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.28.0)(storybook@8.4.7(prettier@2.8.8))(typescript@5.7.2)(vite@5.4.11(@types/node@22.10.1))
+      '@storybook/test':
+        specifier: 'catalog:'
+        version: 8.4.6(storybook@8.4.7(prettier@2.8.8))
+      '@testing-library/jest-dom':
+        specifier: 'catalog:'
+        version: 6.6.3
+      '@testing-library/react':
+        specifier: 'catalog:'
+        version: 16.0.1(@testing-library/dom@10.4.0)(@types/react-dom@18.3.1)(@types/react@18.3.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@testing-library/user-event':
+        specifier: ^14.5.2
+        version: 14.5.2(@testing-library/dom@10.4.0)
+      '@types/react':
+        specifier: ^18.3.12
+        version: 18.3.13
+      happy-dom:
+        specifier: 'catalog:'
+        version: 15.11.7
+      react:
+        specifier: ^18.3.1
+        version: 18.3.1
+      storybook:
+        specifier: 'catalog:'
+        version: 8.4.7(prettier@2.8.8)
+      tsup:
+        specifier: 'catalog:'
+        version: 8.3.5(jiti@2.4.1)(postcss@8.4.49)(tsx@4.19.2)(typescript@5.7.2)(yaml@2.6.1)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.7.2
+      vitest:
+        specifier: 'catalog:'
+        version: 2.1.8(@types/node@22.10.1)(happy-dom@15.11.7)
+
   packages/divider:
     dependencies:
       clsx:
@@ -1938,6 +2011,22 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
+  '@radix-ui/primitive@1.1.1':
+    resolution: {integrity: sha512-SJ31y+Q/zAyShtXJc8x83i9TYdbAfHZ++tUZnvjJJqFjzsdUnKsxPL6IEtBlxKkU7yzer//GQtZSV4GbldL3YA==}
+
+  '@radix-ui/react-checkbox@1.1.3':
+    resolution: {integrity: sha512-HD7/ocp8f1B3e6OHygH0n7ZKjONkhciy1Nh0yuBgObqThc3oyx+vuMfFHKAknXRHHWVE9XvXStxJFyjUmB8PIw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-compose-refs@1.1.0':
     resolution: {integrity: sha512-b4inOtiaOnYf9KWyO3jAeeCG6FeyfY6ldiEPanbUjWd+xIk5wZeHa8yVwmrJ2vderhu/BQvzCrJI0lHd+wIiqw==}
     peerDependencies:
@@ -1947,8 +2036,106 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-compose-refs@1.1.1':
+    resolution: {integrity: sha512-Y9VzoRDSJtgFMUCoiZBDVo084VQ5hfpXxVE+NgkdNsjiDBByiImMZKKhxMwCbdHvhlENG6a833CbFkOQvTricw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-context@1.1.1':
+    resolution: {integrity: sha512-UASk9zi+crv9WteK/NU4PLvOoL3OuE6BWVKNF6hPRBtYBDXQ2u5iu3O59zUlJiTVvkyuycnqrztsHVJwcK9K+Q==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-presence@1.1.2':
+    resolution: {integrity: sha512-18TFr80t5EVgL9x1SwF/YGtfG+l0BS0PRAlCWBDoBEiDQjeKgnNZRVJp/oVBl24sr3Gbfwc/Qpj4OcWTQMsAEg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-primitive@2.0.1':
+    resolution: {integrity: sha512-sHCWTtxwNn3L3fH8qAfnF3WbUZycW93SM1j3NFDzXBiz8D6F5UTTy8G1+WFEaiCdvCVRJWj6N2R4Xq6HdiHmDg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-slot@1.1.0':
     resolution: {integrity: sha512-FUCf5XMfmW4dtYl69pdS4DbxKy8nj4M7SafBgPllysxmdachynNflAdp/gCsnYWNDnge6tI9onzMp5ARYc1KNw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-slot@1.1.1':
+    resolution: {integrity: sha512-RApLLOcINYJA+dMVbOju7MYv1Mb2EBp2nH4HdDzXTSyaR5optlm6Otrz1euW3HbdOR8UmmFK06TD+A9frYWv+g==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-callback-ref@1.1.0':
+    resolution: {integrity: sha512-CasTfvsy+frcFkbXtSJ2Zu9JHpN8TYKxkgJGWbjiZhFivxaeW7rMeZt7QELGVLaYVfFMsKHjb7Ak0nMEe+2Vfw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-controllable-state@1.1.0':
+    resolution: {integrity: sha512-MtfMVJiSr2NjzS0Aa90NPTnvTSg6C/JLCV7ma0W6+OMV78vd8OyRpID+Ng9LxzsPbLeuBnWBA1Nq30AtBIDChw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-layout-effect@1.1.0':
+    resolution: {integrity: sha512-+FPE0rOdziWSrH9athwI1R0HDVbWlEhd+FR+aSDk4uWGmSJ9Z54sdZVDQPZAinJhJXwfT+qnj969mCsT2gfm5w==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-previous@1.1.0':
+    resolution: {integrity: sha512-Z/e78qg2YFnnXcW88A4JmTtm4ADckLno6F7OXotmkQfeuCVaKuYzqAATPhVzl3delXE7CxIV8shofPn3jPc5Og==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-size@1.1.0':
+    resolution: {integrity: sha512-XW3/vWuIXHa+2Uwcc2ABSfcCledmXhhQPlGbfcRXbiUQI5Icjcg19BGCZVKKInYbvUCut/ufbbLLPFC5cbb1hw==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -3866,6 +4053,11 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  lucide-react@0.344.0:
+    resolution: {integrity: sha512-6YyBnn91GB45VuVT96bYCOKElbJzUHqp65vX8cDcu55MQL9T969v4dhGClpljamuI/+KMO9P6w9Acq1CVQGvIQ==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0
+
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
@@ -5737,15 +5929,103 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
+  '@radix-ui/primitive@1.1.1': {}
+
+  '@radix-ui/react-checkbox@1.1.3(@types/react-dom@18.3.1)(@types/react@18.3.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.13)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.1(@types/react@18.3.13)(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.2(@types/react-dom@18.3.1)(@types/react@18.3.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.1(@types/react-dom@18.3.1)(@types/react@18.3.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.13)(react@18.3.1)
+      '@radix-ui/react-use-previous': 1.1.0(@types/react@18.3.13)(react@18.3.1)
+      '@radix-ui/react-use-size': 1.1.0(@types/react@18.3.13)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.13
+      '@types/react-dom': 18.3.1
+
   '@radix-ui/react-compose-refs@1.1.0(@types/react@18.3.13)(react@18.3.1)':
     dependencies:
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.13
 
+  '@radix-ui/react-compose-refs@1.1.1(@types/react@18.3.13)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.13
+
+  '@radix-ui/react-context@1.1.1(@types/react@18.3.13)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.13
+
+  '@radix-ui/react-presence@1.1.2(@types/react-dom@18.3.1)(@types/react@18.3.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.13)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.3.13)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.13
+      '@types/react-dom': 18.3.1
+
+  '@radix-ui/react-primitive@2.0.1(@types/react-dom@18.3.1)(@types/react@18.3.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-slot': 1.1.1(@types/react@18.3.13)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.13
+      '@types/react-dom': 18.3.1
+
   '@radix-ui/react-slot@1.1.0(@types/react@18.3.13)(react@18.3.1)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.13)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.13
+
+  '@radix-ui/react-slot@1.1.1(@types/react@18.3.13)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.13)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.13
+
+  '@radix-ui/react-use-callback-ref@1.1.0(@types/react@18.3.13)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.13
+
+  '@radix-ui/react-use-controllable-state@1.1.0(@types/react@18.3.13)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.13)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.13
+
+  '@radix-ui/react-use-layout-effect@1.1.0(@types/react@18.3.13)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.13
+
+  '@radix-ui/react-use-previous@1.1.0(@types/react@18.3.13)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.13
+
+  '@radix-ui/react-use-size@1.1.0(@types/react@18.3.13)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.3.13)(react@18.3.1)
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.13
@@ -7987,6 +8267,10 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lucide-react@0.344.0(react@18.3.1):
+    dependencies:
+      react: 18.3.1
 
   lz-string@1.5.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -556,9 +556,6 @@ importers:
       '@radix-ui/react-checkbox':
         specifier: ^1.0.4
         version: 1.1.3(@types/react-dom@18.3.1)(@types/react@18.3.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-slot':
-        specifier: ^1.0.2
-        version: 1.1.0(@types/react@18.3.13)(react@18.3.1)
       '@sipe-team/tokens':
         specifier: workspace:^
         version: link:../tokens


### PR DESCRIPTION
## 변경사항

@sipe-team/checkbox 패키지 추가

### 체크박스 컴포넌트 구현 [#6]

- 3가지 크기(sm, md, lg) 지원
- 체크박스 상태(checked, unchecked, disabled) 관리
- label prop을 통한 레이블 텍스트 지원

### CheckboxGroup 컴포넌트 구현

- 여러 체크박스를 하나의 그룹으로 관리 가능
- 선택된 값들을 배열로 관리
- 체크박스 그룹의 name 속성 공유

### Storybook을 통한 컴포넌트 문서화

- 기본 사용법, 크기 변형, 상태 변화 등 예시 추가
- Controlled 상태 관리 예시 추가

## 시각자료

https://github.com/user-attachments/assets/3b5f1164-91de-4b97-9641-118334d47915


## 체크리스트
- [x] 기능 명세를 작성하였나요?
- [x] 테스트 코드를 작성하였나요?

## 추가 논의사항

- 현재 체크박스의 색상은 cyan300을 사용하고 있습니다. 일관, 확장성을 위해 변경할 여지가 있어보입니다.
- 체크박스 그룹에서 indeterminate 상태 지원을 추가하면 좋을 것 같습니다..! (생각해보았는데 좀 어려워서 문서를 찾아보려해요)
- 접근성 관련하여 aria-label, aria-describedby 등의 추가적인 속성 지원을 고려해볼 수 있습니다. (aria 컨밴션을 다루시는지 궁금합니다)

질문, 변경사항 관련해서 코멘트 달아주시면 감사하겠습니다!


+ P 작업에 적혀있어서 진행하고 보니, 대엽님 작업이더라고.. 확인 못해서 죄송합니다! 대엽님 작업 올리면 비교해봐도 재미있을 것 같네요 (제거 부족한부분이 많으니..)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리즈 노트

- **새로운 기능**
    - 체크박스 컴포넌트 및 체크박스 그룹 추가
    - 다양한 크기와 상태를 지원하는 유연한 체크박스 구현
    - Storybook을 통한 체크박스 컴포넌트의 다양한 상태 및 기능 시연

- **개선 사항**
    - 접근성 및 사용자 상호작용을 고려한 체크박스 디자인
    - Radix UI 체크박스 프리미티브 활용
    - CSS 모듈을 통한 스타일링 지원

- **개발 환경**
    - Storybook 설정 추가
    - 단위 테스트 및 타입스크립트 구성 통합
    - Vitest 및 Jest-DOM을 활용한 테스트 환경 구성
    - 새로운 패키지 메타데이터 및 구성 파일 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->