### PR TITLE
docs(contributing): update commit message convention

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -88,11 +88,11 @@ Before proposing changes, please **open an issue** to discuss the bug or feature
    ```
    We recommend following the Conventional Commits standard for clear and consistent commit messages. Below is the suggested structure:
  
-   | Element      | Requirement  | Description                                                                                                                                                            |
-   |--------------|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-   | `<type>`     | **Required** | Describes the purpose of the commit. Examples: `feat`, `fix`, `docs`, `style`, `refactor`, `test`.                                                                     |
-   | `<scope>`    | **Optional** | Specifies the affected module, file, or functionality. Limited to **20 characters** (e.g., `auth`, `header`).                                                          |
-   | `<subject>`  | **Required** | A concise summary of the changes:<br/> - Starts with a lowercase letter.<br/> - Avoid ending with a period (`.`).<br/> - Limited to **50 characters**. - Written in **English**. |
+   | Element      | Requirement  | Description                                                                                                                                                                      |
+   |--------------|--------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+   | `<type>`     | **Required** | Describes the purpose of the commit. Examples: `feat`, `fix`, `docs`, `style`, `refactor`, `test`. Cannot be empty.                                                                              |
+   | `<scope>`    | **Optional** | Specifies the affected module, file, or functionality. Limited to **20 characters** (e.g., `auth`, `header`).                                                                    |
+   | `<subject>`  | **Required** | A concise summary of the changes<br/> - Starts with a lowercase letter<br/> - Avoid ending with a period (.)<br/> - Limited to **50 characters**<br/> - Must contain only English characters, numbers, and basic punctuation (!@#$%^&*(),.?":{}|<>_-)<br/> - Cannot be empty |
 
 
 


### PR DESCRIPTION
## 작업 내용
커밋 메시지 컨벤션에 상세한 정보를 제공하도록 Contributing 가이드를 업데이트했습니다.

## 변경사항

### subject 관련

- 문서에는 영어로 작성해야 한다고만 되어 있지만, 실제로는 영어 문자만 사용 가능해 규칙을 변경했습니다. (subject-english-only 규칙)
- 그리고, 숫자, 공백, 특수문자(!@#$%^&*(),.?":{}|<>_-) 만 허용된다는 구체적인 내용을 추가했습니다.

### 필수 필드

- type-empty, subject-empty 규칙이 Error 레벨로 설정되어 있어 type과 subject는 반드시 있어야 하지만, 이 부분이 명확히 명시되어 있지 않아 추가했습니다

## 체크리스트
- [x] 문서 업데이트 완료
- [x] 프로젝트 스타일 가이드 준수
- [x] 코드 변경 없음 (문서만 수정)

### 추가 전달사항

- 커밋 메시지가 lint를 통과하지 못하는 현상이 발생하여 실제 적용된 lint 규칙을 확인하고 문서를 수정했습니다.
- 현재 [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)을 기반으로 하고 있으며, Angular의 브랜치 전략을 사용하고 있는 것으로 보입니다. 이에 맞춰 브랜치 전략에 대한 컨벤션도 함께 수정하는 것을 고려해볼 수 있을 것 같습니다.