### PR TITLE
chore: enforce ternary operator over logical operator

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -17,6 +17,14 @@ export default tseslint.config(
       '@typescript-eslint/no-explicit-any': 'off',
 
       'no-duplicate-imports': 'off',
+      'no-unused-expressions': ['error', {
+        allowShortCircuit: false,
+        allowTernary: true
+      }],
+      '@typescript-eslint/no-unused-expressions': ['error', {
+        allowShortCircuit: false,
+        allowTernary: true
+      }]
     },
   },
 


### PR DESCRIPTION
## 설명

체크박스 작업 중 의현님 의견을 보고 논리 연산자(`condition && element`)가 아닌 삼항 연산자(`condition ? true : false`) 사용을 강제하는 ESLint 규칙을 추가하면 좋을 것 같아 반영했습니다.

## 변경사항
- ESLint config에 `no-unused-expressions` 규칙 추가
- `allowShortCircuit: false` 설정으로 `&&` 사용 제한
- `allowTernary: true` 설정으로 삼항 연산자 사용 권장

## 예시
변경 전
```tsx
{condition && <Component />}
```

변경후
```tsx
{condition ? <Component /> : null}
```

