### PR TITLE
chore(template): add private:true package.json in template

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,7 +28,7 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
-          version: pnpm changeset version --ignore @sipe-team/package-name
+          version: pnpm changeset version
           publish: pnpm changeset publish
           commit: "chore(release): version packages"
         env:

--- a/.templates/component/package.json
+++ b/.templates/component/package.json
@@ -58,5 +58,6 @@
       "./styles.css": "./dist/index.css"
     }
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "private": true
 }

--- a/package.json
+++ b/package.json
@@ -59,10 +59,7 @@
       "biome lint --write",
       "eslint --fix --flag unstable_ts_config"
     ],
-    "*.{json,css,js,ts,yml,yaml}": [
-      "biome format --write",
-      "biome lint --write"
-    ]
+    "*.{json,css,js,ts}": ["biome format --write", "biome lint --write"]
   },
   "config": {
     "commitizen": {

--- a/scripts/createComponent.ts
+++ b/scripts/createComponent.ts
@@ -79,6 +79,17 @@ class CreateComponentCommand extends Command {
     }
   }
 
+  private async updatePackageJson(targetDir: string): Promise<void> {
+    const packageJsonPath = path.join(targetDir, 'package.json');
+    const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'));
+
+    const { private: _, ...newPackageJson } = packageJson;
+    await fs.writeFile(
+      packageJsonPath,
+      JSON.stringify(newPackageJson, null, 2),
+    );
+  }
+
   async execute() {
     const loading = spinner();
 
@@ -115,6 +126,8 @@ class CreateComponentCommand extends Command {
         kebabCaseName,
         pascalCaseName,
       );
+
+      await this.updatePackageJson(targetDir);
 
       loading.stop('템플릿 복사 완료! ✨');
       outro(`${pascalCaseName} 컴포넌트가 성공적으로 생성되었습니다! 🎉`);


### PR DESCRIPTION
## Changes

- #107 

`--ignore flag`를 세워도 진행되지 않았습니다. changeset쪽에서도 Monorepo 쪽에서는 커스터마이징이 의도처럼 안될 수 있으니 `private: true`를 추가해보라고 나와있어서 이 [방법](https://github.com/changesets/changesets/blob/main/docs/config-file-options.md#ignore-array-of-packages)을 시도해보려고합니다.

## Visuals

![image](https://github.com/user-attachments/assets/ee23ea0d-09f4-417b-be5c-2eea57243283)

> .templates/component/package.json
```json
{
 ...package.json,
 "private": true
}
```

> scripts/createComponent.ts

```ts
private async updatePackageJson(targetDir: string): Promise<void> {
    const packageJsonPath = path.join(targetDir, 'package.json');
    const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'));

    const { private: _, ...newPackageJson } = packageJson;
    await fs.writeFile(
      packageJsonPath,
      JSON.stringify(newPackageJson, null, 2),
    );
  }
```

script를 통해서 컴포넌트를 생성할때, private는 제거토록 했습니다.


## Checklist
- [ ] Have you written the functional specifications?
- [ ] Have you written the test code?

## Additional Discussion Points



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **워크플로우 변경**
	- GitHub Actions 릴리스 워크플로우의 버전 결정 프로세스 업데이트
	- 특정 패키지 제외 옵션 제거

- **패키지 설정**
	- 일부 컴포넌트 템플릿 패키지를 비공개로 표시
	- 패키지 게시 설정 조정

- **개발 도구**
	- Lint-staged 구성 파일 타입 필터링 변경
	- 특정 파일 유형에 대한 포맷 및 린트 규칙 업데이트

- **스크립트 개선**
	- 컴포넌트 생성 스크립트에 패키지 JSON 업데이트 기능 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->