### PR TITLE
chore(chromatic): add workflow trigger condition, URL comment PR

### DIFF
--- a/.github/workflows/chromatic.yaml
+++ b/.github/workflows/chromatic.yaml
@@ -1,8 +1,18 @@
 name: Chromatic
 
 on:
+  pull_request:
+    types: [opened, ready_for_review, synchronize]
+    branches:
+      - main
+    paths:
+      - '**/*.stories.@(js|jsx|ts|tsx)'
   push:
-
+    branches:
+      - main
+    paths:
+      - '**/*.stories.@(js|jsx|ts|tsx)'
+  
 jobs:
   chromatic:
     runs-on: ubuntu-latest
@@ -23,6 +33,14 @@ jobs:
       - name: Install dependencies
         run: pnpm install
       - name: Run Chromatic
+        id: chromatic
         uses: chromaui/action@latest
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+      - name: comment PR
+        uses: thollander/actions-comment-pull-request@v1
+        if: ${{ github.event_name == 'pull_request' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}
+        with:
+          message: "💅 The Storybook has been updated! Click [here](${{ steps.chromatic.outputs.storybookUrl }}) to check it out."

--- a/package.json
+++ b/package.json
@@ -59,10 +59,7 @@
       "biome lint --write",
       "eslint --fix --flag unstable_ts_config"
     ],
-    "*.{json,css,js,ts,yml,yaml}": [
-      "biome format --write",
-      "biome lint --write"
-    ]
+    "*.{json,css,js,ts}": ["biome format --write", "biome lint --write"]
   },
   "config": {
     "commitizen": {


### PR DESCRIPTION
## Changes

###  Chromatic 워크플로우 트리거 조건 추가

- 기존에는 모든 push 이벤트에 대해 Chromatic 워크플로우가 실행되었습니다.
- 이제 스토리(.stories.@(js|jsx|ts|tsx)) 파일에 변경이 있을 때만 워크플로우가 실행되도록 트리거 조건을 추가하였습니다.
- 이를 통해 불필요한 워크플로우 실행을 줄이고 효율성을 높였습니다.

###  PR 코멘트에 업데이트된 Storybook 링크 추가

- 업데이트된 Storybook을 PR 리뷰어가 바로 확인할 수 있도록 PR 코멘트에 링크를 자동으로 추가하는 기능을 추가했습니다.
- Storybook 링크는 Chromatic 실행 결과로 생성되며, PR 코멘트 메시지는 다음과 같습니다:

`💅 The Storybook has been updated! Click [here](링크) to check it out.`

## Visuals
<!-- If there are any screenshots or visual materials, please attach them. -->

## Checklist
- [ ] Have you written the functional specifications?
- [ ] Have you written the test code?

## Additional Discussion Points
<!-- If there are any additional points to be aware of, please specify them. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- GitHub Actions 워크플로우 업데이트
	- 풀 리퀘스트 시 자동으로 Storybook 변경사항에 대한 댓글 추가
	- Lint-staged 구성에서 `yml` 및 `yaml` 파일 타입 제거

<!-- end of auto-generated comment: release notes by coderabbit.ai -->