### PR TITLE
fix(flex) : set default flex direction 'row'

### DIFF
--- a/.changeset/sixty-rules-collect.md
+++ b/.changeset/sixty-rules-collect.md
@@ -1,0 +1,5 @@
+---
+"@sipe-team/flex": patch
+---
+
+fix(flex) : set default flex direction 'row'

--- a/packages/flex/package.json
+++ b/packages/flex/package.json
@@ -26,7 +26,6 @@
   },
   "devDependencies": {
     "@faker-js/faker": "^9.2.0",
-    "@sipe-team/card": "workspace:^",
     "@storybook/addon-essentials": "catalog:",
     "@storybook/addon-interactions": "catalog:",
     "@storybook/addon-links": "catalog:",

--- a/packages/flex/src/Flex.stories.tsx
+++ b/packages/flex/src/Flex.stories.tsx
@@ -1,4 +1,3 @@
-import { Card } from '@sipe-team/card';
 import type { Meta, StoryObj } from '@storybook/react';
 import { Flex } from './Flex';
 
@@ -19,14 +18,7 @@ const meta = {
     },
     justify: {
       control: 'select',
-      options: [
-        'flex-start',
-        'flex-end',
-        'center',
-        'space-between',
-        'space-around',
-        'space-evenly',
-      ],
+      options: ['flex-start', 'flex-end', 'center', 'space-between', 'space-around', 'space-evenly'],
       description: 'Justify content',
     },
     wrap: {
@@ -48,14 +40,31 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+const Box = ({ style, children }: { style?: React.CSSProperties; children?: React.ReactNode }) => (
+  <div
+    style={{
+      width: '100%',
+      height: '100%',
+      minHeight: '5rem',
+      backgroundClip: 'padding-box',
+      backgroundImage: `url("data:image/svg+xml,%3Csvg width='6' height='6' viewBox='0 0 6 6' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='%239C92AC' fill-opacity='0.2' fill-rule='evenodd'%3E%3Cpath d='M5 0h1L0 6V5zM6 5v1H5z'/%3E%3C/g%3E%3C/svg%3E")`,
+      backgroundRepeat: 'repeat',
+      borderWidth: '1px',
+      backgroundColor: '#e4e4e7',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      ...style,
+    }}
+  >
+    {children}
+  </div>
+);
+
 export const Basic: Story = {
   args: {
     gap: '1rem',
-    children: [
-      <Card key="1" style={{ height: '20px', width: '100%' }} />,
-      <Card key="2" style={{ height: '20px', width: '100%' }} />,
-      <Card key="3" style={{ height: '20px', width: '100%' }} />,
-    ],
+    children: [<Box key="1" />, <Box key="2" />, <Box key="3" />],
   },
 };
 
@@ -64,38 +73,7 @@ export const Direction: Story = {
     direction: 'column',
     gap: '1rem',
     style: { width: '100%' },
-    children: [
-      <Card
-        key="1"
-        style={{
-          padding: '0px',
-          height: '60px',
-          width: '100%',
-        }}
-      >
-        1
-      </Card>,
-      <Card
-        key="2"
-        style={{
-          padding: '0px',
-          height: '60px',
-          width: '100%',
-        }}
-      >
-        2
-      </Card>,
-      <Card
-        key="3"
-        style={{
-          padding: '0px',
-          height: '60px',
-          width: '100%',
-        }}
-      >
-        3
-      </Card>,
-    ],
+    children: [<Box key="1" />, <Box key="2" />, <Box key="3" />],
   },
 };
 
@@ -105,18 +83,9 @@ export const Align: Story = {
     gap: '1rem',
     style: { width: '100%' },
     children: [
-      <Card
-        key="1"
-        style={{ padding: '0px', height: '36px', width: '100%' }}
-      />,
-      <Card
-        key="2"
-        style={{ padding: '0px', height: '48px', width: '100%' }}
-      />,
-      <Card
-        key="3"
-        style={{ padding: '0px', height: '60px', width: '100%' }}
-      />,
+      <Box key="1" style={{ height: '5rem' }} />,
+      <Box key="2" style={{ height: '7rem' }} />,
+      <Box key="3" style={{ height: '9rem' }} />,
     ],
   },
 };
@@ -125,34 +94,34 @@ export const Justify: Story = {
   render: () => (
     <Flex direction="column" gap="2rem">
       <Flex justify="flex-start" gap="1rem">
-        <Card style={{ minWidth: '150px', height: '30px' }} />
-        <Card style={{ minWidth: '150px', height: '30px' }}>flex-start</Card>
-        <Card style={{ minWidth: '150px', height: '30px' }} />
+        <Box style={{ width: '150px' }} />
+        <Box style={{ width: '150px' }}>flex-start</Box>
+        <Box style={{ width: '150px' }} />
       </Flex>
       <Flex justify="center" gap="1rem">
-        <Card style={{ width: '150px', height: '30px' }} />
-        <Card style={{ width: '150px', height: '30px' }}>center</Card>
-        <Card style={{ width: '150px', height: '30px' }} />
+        <Box style={{ width: '150px' }} />
+        <Box style={{ width: '150px' }}>center</Box>
+        <Box style={{ width: '150px' }} />
       </Flex>
       <Flex justify="flex-end" gap="1rem">
-        <Card style={{ width: '150px', height: '30px' }} />
-        <Card style={{ width: '150px', height: '30px' }}>flex-end</Card>
-        <Card style={{ width: '150px', height: '30px' }} />
+        <Box style={{ width: '150px' }} />
+        <Box style={{ width: '150px' }}>flex-end</Box>
+        <Box style={{ width: '150px' }} />
       </Flex>
       <Flex justify="space-between" gap="1rem">
-        <Card style={{ width: '150px', height: '30px' }} />
-        <Card style={{ width: '150px', height: '30px' }}>space-between</Card>
-        <Card style={{ width: '150px', height: '30px' }} />
+        <Box style={{ width: '150px' }} />
+        <Box style={{ width: '150px' }}>space-between</Box>
+        <Box style={{ width: '150px' }} />
       </Flex>
       <Flex justify="space-around" gap="1rem">
-        <Card style={{ width: '150px', height: '30px' }} />
-        <Card style={{ width: '150px', height: '30px' }}>space-around</Card>
-        <Card style={{ width: '150px', height: '30px' }} />
+        <Box style={{ width: '150px' }} />
+        <Box style={{ width: '150px' }}>space-around</Box>
+        <Box style={{ width: '150px' }} />
       </Flex>
       <Flex justify="space-evenly" gap="1rem">
-        <Card style={{ width: '150px', height: '30px' }} />
-        <Card style={{ width: '150px', height: '30px' }}>space-evenly</Card>
-        <Card style={{ width: '150px', height: '30px' }} />
+        <Box style={{ width: '150px' }} />
+        <Box style={{ width: '150px' }}>space-evenly</Box>
+        <Box style={{ width: '150px' }} />
       </Flex>
     </Flex>
   ),
@@ -164,9 +133,9 @@ export const Wrap: Story = {
     gap: '1rem',
     style: { maxWidth: '400px' },
     children: [
-      <Card key="1" style={{ width: '150px' }} />,
-      <Card key="2" style={{ width: '150px' }} />,
-      <Card key="3" style={{ width: '150px' }} />,
+      <Box key="1" style={{ width: '150px' }} />,
+      <Box key="2" style={{ width: '150px' }} />,
+      <Box key="3" style={{ width: '150px' }} />,
     ],
   },
 };

--- a/packages/flex/src/Flex.test.tsx
+++ b/packages/flex/src/Flex.test.tsx
@@ -5,7 +5,7 @@ import { describe, expect, it } from 'vitest';
 import { Flex } from './Flex';
 
 describe('Flex', () => {
-  it('flex 컴포넌트는 기본적으로 flex 속성을 가지고 있다.', () => {
+  it('flex 컴포넌트는 props를 전달하지 않으면 flex의 기본값으로 설정된다.', () => {
     render(
       <Flex data-testid="flex-container">
         <div>item 1</div>
@@ -15,7 +15,13 @@ describe('Flex', () => {
 
     const flexContainer = screen.getByTestId('flex-container');
     expect(flexContainer).toBeInTheDocument();
-    expect(flexContainer).toHaveStyle({ display: 'flex' });
+    expect(flexContainer).toHaveStyle({
+      display: 'flex',
+      flexDirection: 'row',
+      alignItems: 'normal',
+      justifyContent: 'normal',
+      flexWrap: 'nowrap',
+    });
   });
 
   it('flex 컴포넌트에 className을 주입하면 추가로 전달한다.', () => {
@@ -73,24 +79,19 @@ describe('Flex', () => {
     });
 
     describe('wrap', () => {
-      it.each([
-        { wrap: 'wrap' },
-        { wrap: 'nowrap' },
-        { wrap: 'wrap-reverse' },
-      ] satisfies Array<{ wrap: CSSProperties['flexWrap'] }>)(
-        'flex의 wrap prop에 $wrap 속성을 주입하면 해당 속성을 적용한다.',
-        ({ wrap }) => {
-          render(
-            <Flex data-testid="flex-container" wrap={wrap}>
-              <div>item 1</div>
-              <div>item 2</div>
-            </Flex>,
-          );
+      it.each([{ wrap: 'wrap' }, { wrap: 'nowrap' }, { wrap: 'wrap-reverse' }] satisfies Array<{
+        wrap: CSSProperties['flexWrap'];
+      }>)('flex의 wrap prop에 $wrap 속성을 주입하면 해당 속성을 적용한다.', ({ wrap }) => {
+        render(
+          <Flex data-testid="flex-container" wrap={wrap}>
+            <div>item 1</div>
+            <div>item 2</div>
+          </Flex>,
+        );
 
-          const flexContainer = screen.getByTestId('flex-container');
-          expect(flexContainer).toHaveStyle({ flexWrap: wrap });
-        },
-      );
+        const flexContainer = screen.getByTestId('flex-container');
+        expect(flexContainer).toHaveStyle({ flexWrap: wrap });
+      });
     });
 
     describe('direction', () => {
@@ -124,58 +125,49 @@ describe('Flex', () => {
           { basis: 'content' },
         ] satisfies Array<{
           basis: CSSProperties['flexBasis'];
-        }>)(
-          'flex의 basis prop에 $basis 속성을 주입하면 해당 속성을 적용한다.',
-          ({ basis }) => {
-            render(
-              <Flex data-testid="flex-container" basis={basis}>
-                <div>item 1</div>
-                <div>item 2</div>
-              </Flex>,
-            );
+        }>)('flex의 basis prop에 $basis 속성을 주입하면 해당 속성을 적용한다.', ({ basis }) => {
+          render(
+            <Flex data-testid="flex-container" basis={basis}>
+              <div>item 1</div>
+              <div>item 2</div>
+            </Flex>,
+          );
 
-            const flexContainer = screen.getByTestId('flex-container');
-            expect(flexContainer).toHaveStyle({ flexBasis: basis });
-          },
-        );
+          const flexContainer = screen.getByTestId('flex-container');
+          expect(flexContainer).toHaveStyle({ flexBasis: basis });
+        });
       });
 
       describe('grow', () => {
         it.each([{ grow: 0 }, { grow: 1 }, { grow: 2 }] satisfies Array<{
           grow: CSSProperties['flexGrow'];
-        }>)(
-          'flex의 grow prop에 $grow 속성을 주입하면 해당 속성을 적용한다.',
-          ({ grow }) => {
-            render(
-              <Flex data-testid="flex-container" grow={grow}>
-                <div>item 1</div>
-                <div>item 2</div>
-              </Flex>,
-            );
+        }>)('flex의 grow prop에 $grow 속성을 주입하면 해당 속성을 적용한다.', ({ grow }) => {
+          render(
+            <Flex data-testid="flex-container" grow={grow}>
+              <div>item 1</div>
+              <div>item 2</div>
+            </Flex>,
+          );
 
-            const flexContainer = screen.getByTestId('flex-container');
-            expect(flexContainer).toHaveStyle({ flexGrow: grow });
-          },
-        );
+          const flexContainer = screen.getByTestId('flex-container');
+          expect(flexContainer).toHaveStyle({ flexGrow: grow });
+        });
       });
 
       describe('shrink', () => {
         it.each([{ shrink: 0 }, { shrink: 1 }, { shrink: 2 }] satisfies Array<{
           shrink: CSSProperties['flexShrink'];
-        }>)(
-          'flex의 shrink prop에 $shrink 속성을 주입하면 해당 속성을 적용한다.',
-          ({ shrink }) => {
-            render(
-              <Flex data-testid="flex-container" shrink={shrink}>
-                <div>item 1</div>
-                <div>item 2</div>
-              </Flex>,
-            );
+        }>)('flex의 shrink prop에 $shrink 속성을 주입하면 해당 속성을 적용한다.', ({ shrink }) => {
+          render(
+            <Flex data-testid="flex-container" shrink={shrink}>
+              <div>item 1</div>
+              <div>item 2</div>
+            </Flex>,
+          );
 
-            const flexContainer = screen.getByTestId('flex-container');
-            expect(flexContainer).toHaveStyle({ flexShrink: shrink });
-          },
-        );
+          const flexContainer = screen.getByTestId('flex-container');
+          expect(flexContainer).toHaveStyle({ flexShrink: shrink });
+        });
       });
 
       describe('inline', () => {
@@ -195,20 +187,17 @@ describe('Flex', () => {
       describe('gap', () => {
         it.each([{ gap: '10px' }, { gap: '1rem' }] satisfies Array<{
           gap: CSSProperties['gap'];
-        }>)(
-          'flex의 gap prop에 $gap 속성을 주입하면 해당 속성을 적용한다.',
-          ({ gap }) => {
-            render(
-              <Flex data-testid="flex-container" gap={gap}>
-                <div>item 1</div>
-                <div>item 2</div>
-              </Flex>,
-            );
+        }>)('flex의 gap prop에 $gap 속성을 주입하면 해당 속성을 적용한다.', ({ gap }) => {
+          render(
+            <Flex data-testid="flex-container" gap={gap}>
+              <div>item 1</div>
+              <div>item 2</div>
+            </Flex>,
+          );
 
-            const flexContainer = screen.getByTestId('flex-container');
-            expect(flexContainer).toHaveStyle({ gap });
-          },
-        );
+          const flexContainer = screen.getByTestId('flex-container');
+          expect(flexContainer).toHaveStyle({ gap });
+        });
       });
     });
   });

--- a/packages/flex/src/Flex.tsx
+++ b/packages/flex/src/Flex.tsx
@@ -1,11 +1,6 @@
 import { Slot } from '@radix-ui/react-slot';
 import { clsx as cx } from 'clsx';
-import {
-  type CSSProperties,
-  type ComponentProps,
-  type ForwardedRef,
-  forwardRef,
-} from 'react';
+import { type CSSProperties, type ComponentProps, type ForwardedRef, forwardRef } from 'react';
 import styles from './Flex.module.css';
 
 export interface FlexProps extends ComponentProps<'div'> {
@@ -44,10 +39,10 @@ export const Flex = forwardRef(function Flex(
 
   const flexStyle = {
     '--flex-display': inline ? 'inline-flex' : 'flex',
-    '--flex-direction': direction,
-    '--flex-align': align,
-    '--flex-justify': justify,
-    '--flex-wrap': wrap,
+    '--flex-direction': direction ?? 'row',
+    '--flex-align': align ?? 'normal',
+    '--flex-justify': justify ?? 'normal',
+    '--flex-wrap': wrap ?? 'nowrap',
     '--flex-gap': gap,
     '--flex-basis': basis,
     '--flex-grow': grow,
@@ -56,12 +51,7 @@ export const Flex = forwardRef(function Flex(
   } as React.CSSProperties;
 
   return (
-    <Component
-      ref={ref}
-      className={cx(styles.flex, className)}
-      style={flexStyle}
-      {...rest}
-    >
+    <Component ref={ref} className={cx(styles.flex, className)} style={flexStyle} {...rest}>
       {children}
     </Component>
   );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -706,9 +706,6 @@ importers:
       '@faker-js/faker':
         specifier: ^9.2.0
         version: 9.2.0
-      '@sipe-team/card':
-        specifier: workspace:^
-        version: link:../card
       '@storybook/addon-essentials':
         specifier: 'catalog:'
         version: 8.4.6(@types/react@18.3.13)(storybook@8.5.0(prettier@2.8.8))


### PR DESCRIPTION
## Changes
- #120
- Set explicit 'row' as default flex direction https://github.com/sipe-team/3-2_side/pull/121/commits/42ca7b46d50c9732a5a4e647c7e8dc2a2427f885
- Added comprehensive default props test coverage https://github.com/sipe-team/3-2_side/pull/121/commits/42ca7b46d50c9732a5a4e647c7e8dc2a2427f885
- Improved Storybook examples with internal Box component https://github.com/sipe-team/3-2_side/pull/121/commits/459a78a9e5282dbfeb71b8c349fefb97fdb84e5c
- Cleaned up `@sipe-team/card` package dependency https://github.com/sipe-team/3-2_side/pull/121/commits/459a78a9e5282dbfeb71b8c349fefb97fdb84e5c

## Visuals
<img width="1042" alt="image" src="https://github.com/user-attachments/assets/a4de6660-aa24-42af-b856-7eb5f4fdad75" />


## Checklist
- [x] Have you written the functional specifications?
- [x] Have you written the test code?

## Additional Discussion Points
<!-- If there are any additional points to be aware of, please specify them. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- Flex 컴포넌트의 기본 방향을 수평 행(row)으로 설정

- **개선 사항**
	- Flex 컴포넌트의 기본 스타일 속성 강화
	- 의존성 관리를 위한 패키지 구조 최적화

- **버그 수정**
	- CSS 속성의 기본값 처리 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->